### PR TITLE
style: cargo fmt (unified CI prep)

### DIFF
--- a/examples/classify_tune_demo.rs
+++ b/examples/classify_tune_demo.rs
@@ -174,8 +174,7 @@ fn main() {
             // Quick forward pass for accuracy
             let hidden = pipeline.model.forward_hidden(&token_ids);
             let logits = pipeline.classifier.forward(&hidden, token_ids.len());
-            let logits_slice: Vec<f32> =
-                logits.data().as_slice().expect("contiguous").to_vec();
+            let logits_slice: Vec<f32> = logits.data().as_slice().expect("contiguous").to_vec();
             let pred = logits_slice
                 .iter()
                 .enumerate()
@@ -190,10 +189,7 @@ fn main() {
         let accuracy = correct as f64 / samples.len() as f64;
         let elapsed_ms = trial_start.elapsed().as_millis() as u64;
 
-        println!(
-            "  -> loss={avg_loss:.4}, accuracy={:.1}%, time={elapsed_ms}ms",
-            accuracy * 100.0
-        );
+        println!("  -> loss={avg_loss:.4}, accuracy={:.1}%, time={elapsed_ms}ms", accuracy * 100.0);
 
         // Record trial in tuner leaderboard
         let summary = TrialSummary {
@@ -227,7 +223,13 @@ fn main() {
         let (lr, rank, alpha, ..) = extract_trial_params(&trial.config);
         println!(
             "  {:<6} {:<10.4} {:<10.1}% {:<8.2e} {:<6} {:<8.1} {:<10}ms",
-            trial.id, trial.val_loss, trial.val_accuracy * 100.0, lr, rank, alpha, trial.time_ms
+            trial.id,
+            trial.val_loss,
+            trial.val_accuracy * 100.0,
+            lr,
+            rank,
+            alpha,
+            trial.time_ms
         );
     }
 

--- a/examples/cluster_training.rs
+++ b/examples/cluster_training.rs
@@ -54,10 +54,7 @@ fn print_usage() {
 }
 
 fn parse_config_path(args: &[String]) -> Option<PathBuf> {
-    args.iter()
-        .position(|a| a == "--config")
-        .and_then(|i| args.get(i + 1))
-        .map(PathBuf::from)
+    args.iter().position(|a| a == "--config").and_then(|i| args.get(i + 1)).map(PathBuf::from)
 }
 
 fn load_or_default_cluster(path: Option<&Path>) -> ClusterConfig {
@@ -113,26 +110,10 @@ fn print_cluster_info(cluster: &ClusterConfig) {
 
 fn create_demo_jobs() -> Vec<AdapterJob> {
     vec![
-        AdapterJob {
-            adapter_idx: 0,
-            budget_mb: 6000,
-            label: "code-review".to_string(),
-        },
-        AdapterJob {
-            adapter_idx: 1,
-            budget_mb: 6000,
-            label: "bug-fixing".to_string(),
-        },
-        AdapterJob {
-            adapter_idx: 2,
-            budget_mb: 3000,
-            label: "docstring-gen".to_string(),
-        },
-        AdapterJob {
-            adapter_idx: 3,
-            budget_mb: 3000,
-            label: "test-gen".to_string(),
-        },
+        AdapterJob { adapter_idx: 0, budget_mb: 6000, label: "code-review".to_string() },
+        AdapterJob { adapter_idx: 1, budget_mb: 6000, label: "bug-fixing".to_string() },
+        AdapterJob { adapter_idx: 2, budget_mb: 3000, label: "docstring-gen".to_string() },
+        AdapterJob { adapter_idx: 3, budget_mb: 3000, label: "test-gen".to_string() },
     ]
 }
 
@@ -314,9 +295,7 @@ rank = 8
                     entry.data.display(),
                     entry.checkpoint.display(),
                     entry.rank.map_or("default".to_string(), |r| r.to_string()),
-                    entry
-                        .learning_rate
-                        .map_or("default".to_string(), |lr| format!("{lr}"))
+                    entry.learning_rate.map_or("default".to_string(), |lr| format!("{lr}"))
                 );
             }
         }
@@ -331,10 +310,7 @@ fn show_health_check(cluster: &ClusterConfig) {
     let results = check_cluster_health(cluster);
     for h in &results {
         let status = if h.reachable { "OK" } else { "UNREACHABLE" };
-        let apr = h
-            .apr_version
-            .as_deref()
-            .unwrap_or("not found");
+        let apr = h.apr_version.as_deref().unwrap_or("not found");
         let err = h.error.as_deref().unwrap_or("");
         if h.reachable {
             println!("  {}: {status} (apr: {apr})", h.node_name);

--- a/examples/gpu_ledger.rs
+++ b/examples/gpu_ledger.rs
@@ -54,10 +54,8 @@ fn main() {
 
     // --reserve <MB> --task <name>: create a reservation
     if let Some(pos) = args.iter().position(|a| a == "--reserve") {
-        let budget_mb: usize = args
-            .get(pos + 1)
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| {
+        let budget_mb: usize =
+            args.get(pos + 1).and_then(|s| s.parse().ok()).unwrap_or_else(|| {
                 eprintln!("--reserve requires a number (MB)");
                 std::process::exit(1);
             });
@@ -86,10 +84,8 @@ fn main() {
 
     // --wait <MB>: wait for VRAM availability
     if let Some(pos) = args.iter().position(|a| a == "--wait") {
-        let budget_mb: usize = args
-            .get(pos + 1)
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| {
+        let budget_mb: usize =
+            args.get(pos + 1).and_then(|s| s.parse().ok()).unwrap_or_else(|| {
                 eprintln!("--wait requires a number (MB)");
                 std::process::exit(1);
             });
@@ -115,10 +111,8 @@ fn main() {
 
     // --guard <MB>: guard demo (acquire, update actual, release)
     if let Some(pos) = args.iter().position(|a| a == "--guard") {
-        let budget_mb: usize = args
-            .get(pos + 1)
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| {
+        let budget_mb: usize =
+            args.get(pos + 1).and_then(|s| s.parse().ok()).unwrap_or_else(|| {
                 eprintln!("--guard requires a number (MB)");
                 std::process::exit(1);
             });

--- a/examples/multi_adapter_training.rs
+++ b/examples/multi_adapter_training.rs
@@ -114,9 +114,16 @@ fn run_training(multi: &mut MultiAdapterPipeline, epochs: usize, schedule: Adapt
         println!();
         for epoch in 0..epochs {
             multi.reset_epoch(epoch as u64);
-            println!("Epoch {} | {} adapters scheduled ({schedule:?})", epoch + 1, multi.num_adapters());
+            println!(
+                "Epoch {} | {} adapters scheduled ({schedule:?})",
+                epoch + 1,
+                multi.num_adapters()
+            );
             for i in 0..multi.num_adapters() {
-                println!("  Adapter {i}: {} train samples, cursor=0", multi.adapters[i].train_samples.len());
+                println!(
+                    "  Adapter {i}: {} train samples, cursor=0",
+                    multi.adapters[i].train_samples.len()
+                );
             }
         }
     }
@@ -138,8 +145,16 @@ fn run_real_training(multi: &mut MultiAdapterPipeline, epochs: usize) {
         }
 
         for (i, losses) in epoch_losses.iter().enumerate() {
-            let avg = if losses.is_empty() { 0.0 } else { losses.iter().sum::<f32>() / losses.len() as f32 };
-            println!("Epoch {} | Adapter {i}: avg_loss={avg:.4} ({} steps)", epoch + 1, losses.len());
+            let avg = if losses.is_empty() {
+                0.0
+            } else {
+                losses.iter().sum::<f32>() / losses.len() as f32
+            };
+            println!(
+                "Epoch {} | Adapter {i}: avg_loss={avg:.4} ({} steps)",
+                epoch + 1,
+                losses.len()
+            );
         }
     }
 }
@@ -179,10 +194,7 @@ fn generate_synthetic_samples(seed: usize, count: usize) -> Vec<InstructSample> 
 }
 
 fn parse_arg(args: &[String], flag: &str) -> Option<usize> {
-    args.iter()
-        .position(|a| a == flag)
-        .and_then(|i| args.get(i + 1))
-        .and_then(|v| v.parse().ok())
+    args.iter().position(|a| a == flag).and_then(|i| args.get(i + 1)).and_then(|v| v.parse().ok())
 }
 
 fn parse_schedule(args: &[String]) -> AdapterSchedule {

--- a/examples/profile_cuda_trainer.rs
+++ b/examples/profile_cuda_trainer.rs
@@ -10,7 +10,7 @@
 
 #[cfg(feature = "cuda")]
 fn main() {
-    use entrenar::train::{CudaTransformerTrainer, TransformerTrainConfig, LMBatch};
+    use entrenar::train::{CudaTransformerTrainer, LMBatch, TransformerTrainConfig};
     use entrenar::transformer::TransformerConfig;
 
     println!("=== KAIZEN-047: CUDA Trainer Step Profiler ===\n");
@@ -22,30 +22,40 @@ fn main() {
     let (model_config, max_seq, num_steps, vocab) = if large {
         // 350M-class: 24 layers, 1024 hidden, 128 seq_len
         println!("Mode: LARGE (24L, 1024H, seq=128, vocab=32000, 20 steps)");
-        (TransformerConfig {
-            hidden_size: 1024,
-            intermediate_size: 4096,
-            num_hidden_layers: 24,
-            num_attention_heads: 16,
-            num_kv_heads: 16,
-            vocab_size: 32000,
-            max_position_embeddings: 512,
-            ..TransformerConfig::tiny()
-        }, 128_usize, 20_usize, 32000_usize)
+        (
+            TransformerConfig {
+                hidden_size: 1024,
+                intermediate_size: 4096,
+                num_hidden_layers: 24,
+                num_attention_heads: 16,
+                num_kv_heads: 16,
+                vocab_size: 32000,
+                max_position_embeddings: 512,
+                ..TransformerConfig::tiny()
+            },
+            128_usize,
+            20_usize,
+            32000_usize,
+        )
     } else {
         // Tiny model for quick smoke test
         println!("Mode: TINY (2L, 128H, seq=32, vocab=1000, 20 steps)");
         println!("  Use --large for production-scale profiling");
-        (TransformerConfig {
-            hidden_size: 128,
-            intermediate_size: 512,
-            num_hidden_layers: 2,
-            num_attention_heads: 4,
-            num_kv_heads: 4,
-            vocab_size: 1000,
-            max_position_embeddings: 64,
-            ..TransformerConfig::tiny()
-        }, 32_usize, 20_usize, 1000_usize)
+        (
+            TransformerConfig {
+                hidden_size: 128,
+                intermediate_size: 512,
+                num_hidden_layers: 2,
+                num_attention_heads: 4,
+                num_kv_heads: 4,
+                vocab_size: 1000,
+                max_position_embeddings: 64,
+                ..TransformerConfig::tiny()
+            },
+            32_usize,
+            20_usize,
+            1000_usize,
+        )
     };
 
     let mut train_config = TransformerTrainConfig::new(model_config);

--- a/src/aprender_compat.rs
+++ b/src/aprender_compat.rs
@@ -127,39 +127,60 @@ pub mod estimators {
 
     /// LinearRegression: OLS linear regression
     #[derive(Debug, Default)]
-    pub struct LinearRegression { pub weights: Vec<f32> }
+    pub struct LinearRegression {
+        pub weights: Vec<f32>,
+    }
 
     /// LogisticRegression: logistic classifier
     #[derive(Debug, Default)]
-    pub struct LogisticRegression { pub weights: Vec<f32> }
+    pub struct LogisticRegression {
+        pub weights: Vec<f32>,
+    }
 
     /// Ridge regression (L2 regularization)
     #[derive(Debug, Default)]
-    pub struct Ridge { pub alpha: f32, pub weights: Vec<f32> }
+    pub struct Ridge {
+        pub alpha: f32,
+        pub weights: Vec<f32>,
+    }
 
     /// Lasso regression (L1 regularization)
     #[derive(Debug, Default)]
-    pub struct Lasso { pub alpha: f32, pub weights: Vec<f32> }
+    pub struct Lasso {
+        pub alpha: f32,
+        pub weights: Vec<f32>,
+    }
 
     /// DecisionTree classifier/regressor
     #[derive(Debug, Default)]
-    pub struct DecisionTree { pub max_depth: usize }
+    pub struct DecisionTree {
+        pub max_depth: usize,
+    }
 
     /// RandomForest ensemble
     #[derive(Debug, Default)]
-    pub struct RandomForest { pub n_trees: usize }
+    pub struct RandomForest {
+        pub n_trees: usize,
+    }
 
     /// GradientBoosting ensemble
     #[derive(Debug, Default)]
-    pub struct GradientBoosting { pub n_estimators: usize, pub learning_rate: f32 }
+    pub struct GradientBoosting {
+        pub n_estimators: usize,
+        pub learning_rate: f32,
+    }
 
     /// SVM: Support Vector Machine
     #[derive(Debug, Default)]
-    pub struct SVM { pub kernel: String }
+    pub struct SVM {
+        pub kernel: String,
+    }
 
     /// KNeighbors: k-Nearest Neighbors
     #[derive(Debug, Default)]
-    pub struct KNeighbors { pub k: usize }
+    pub struct KNeighbors {
+        pub k: usize,
+    }
 
     /// NaiveBayes classifier
     #[derive(Debug, Default)]
@@ -167,17 +188,27 @@ pub mod estimators {
 
     /// KMeans clustering
     #[derive(Debug, Default)]
-    pub struct KMeans { pub k: usize }
+    pub struct KMeans {
+        pub k: usize,
+    }
 
     /// DBSCAN density-based clustering
     #[derive(Debug, Default)]
-    pub struct DBSCAN { pub eps: f32, pub min_points: usize }
+    pub struct DBSCAN {
+        pub eps: f32,
+        pub min_points: usize,
+    }
 
     /// PCA: Principal Component Analysis
     #[derive(Debug, Default)]
-    pub struct PCA { pub n_components: usize }
+    pub struct PCA {
+        pub n_components: usize,
+    }
 
     /// StandardScaler: feature standardization
     #[derive(Debug, Clone, Default)]
-    pub struct StandardScaler { pub mean: Vec<f32>, pub std: Vec<f32> }
+    pub struct StandardScaler {
+        pub mean: Vec<f32>,
+        pub std: Vec<f32>,
+    }
 }

--- a/src/autograd/cuda_backward/cache.rs
+++ b/src/autograd/cuda_backward/cache.rs
@@ -104,8 +104,8 @@ pub fn pre_warm_lora_backward_kernels(
     quantize_nf4: bool,
 ) -> Result<()> {
     use trueno_gpu::kernels::backward::{
-        BatchedRmsNormBackwardKernel, BatchedSoftmaxBackwardKernel,
-        GemmBackwardAKernel, GemmBackwardBKernel, SiluBackwardKernel,
+        BatchedRmsNormBackwardKernel, BatchedSoftmaxBackwardKernel, GemmBackwardAKernel,
+        GemmBackwardBKernel, SiluBackwardKernel,
     };
     use trueno_gpu::kernels::Kernel;
 
@@ -142,34 +142,76 @@ pub fn pre_warm_lora_backward_kernels(
 
     // ── LoRA backward shapes (always needed) ──
     // gemm_backward_b: weight gradients
-    warm!(format!("gemm_backward_b_{s}_{r}_{qd}"), GemmBackwardBKernel::tiled_unrolled(s, r, qd, tile));
+    warm!(
+        format!("gemm_backward_b_{s}_{r}_{qd}"),
+        GemmBackwardBKernel::tiled_unrolled(s, r, qd, tile)
+    );
     if kv != qd {
-        warm!(format!("gemm_backward_b_{s}_{r}_{kv}"), GemmBackwardBKernel::tiled_unrolled(s, r, kv, tile));
+        warm!(
+            format!("gemm_backward_b_{s}_{r}_{kv}"),
+            GemmBackwardBKernel::tiled_unrolled(s, r, kv, tile)
+        );
     }
-    warm!(format!("gemm_backward_b_{s}_{h}_{r}"), GemmBackwardBKernel::tiled_unrolled(s, h, r, tile));
+    warm!(
+        format!("gemm_backward_b_{s}_{h}_{r}"),
+        GemmBackwardBKernel::tiled_unrolled(s, h, r, tile)
+    );
 
     // gemm_backward_a: input gradients
-    warm!(format!("gemm_backward_a_{s}_{qd}_{r}"), GemmBackwardAKernel::tiled_unrolled(s, qd, r, tile));
+    warm!(
+        format!("gemm_backward_a_{s}_{qd}_{r}"),
+        GemmBackwardAKernel::tiled_unrolled(s, qd, r, tile)
+    );
     if kv != qd {
-        warm!(format!("gemm_backward_a_{s}_{kv}_{r}"), GemmBackwardAKernel::tiled_unrolled(s, kv, r, tile));
+        warm!(
+            format!("gemm_backward_a_{s}_{kv}_{r}"),
+            GemmBackwardAKernel::tiled_unrolled(s, kv, r, tile)
+        );
     }
-    warm!(format!("gemm_backward_a_{s}_{r}_{h}"), GemmBackwardAKernel::tiled_unrolled(s, r, h, tile));
+    warm!(
+        format!("gemm_backward_a_{s}_{r}_{h}"),
+        GemmBackwardAKernel::tiled_unrolled(s, r, h, tile)
+    );
 
     // ── Full fp32 backward shapes (non-NF4 mode) ──
     if !quantize_nf4 {
         // Attention backward: Q/O (S,H,H), K/V (S,kv,H)
-        warm!(format!("gemm_backward_a_{s}_{h}_{h}"), GemmBackwardAKernel::tiled_unrolled(s, h, h, tile));
-        warm!(format!("gemm_backward_b_{s}_{h}_{h}"), GemmBackwardBKernel::tiled_unrolled(s, h, h, tile));
+        warm!(
+            format!("gemm_backward_a_{s}_{h}_{h}"),
+            GemmBackwardAKernel::tiled_unrolled(s, h, h, tile)
+        );
+        warm!(
+            format!("gemm_backward_b_{s}_{h}_{h}"),
+            GemmBackwardBKernel::tiled_unrolled(s, h, h, tile)
+        );
         if kv != h {
-            warm!(format!("gemm_backward_a_{s}_{kv}_{h}"), GemmBackwardAKernel::tiled_unrolled(s, kv, h, tile));
-            warm!(format!("gemm_backward_b_{s}_{kv}_{h}"), GemmBackwardBKernel::tiled_unrolled(s, kv, h, tile));
+            warm!(
+                format!("gemm_backward_a_{s}_{kv}_{h}"),
+                GemmBackwardAKernel::tiled_unrolled(s, kv, h, tile)
+            );
+            warm!(
+                format!("gemm_backward_b_{s}_{kv}_{h}"),
+                GemmBackwardBKernel::tiled_unrolled(s, kv, h, tile)
+            );
         }
 
         // FFN backward: gate/up (S,H,I), down (S,I,H)
-        warm!(format!("gemm_backward_a_{s}_{h}_{i}"), GemmBackwardAKernel::tiled_unrolled(s, h, i, tile));
-        warm!(format!("gemm_backward_b_{s}_{h}_{i}"), GemmBackwardBKernel::tiled_unrolled(s, h, i, tile));
-        warm!(format!("gemm_backward_a_{s}_{i}_{h}"), GemmBackwardAKernel::tiled_unrolled(s, i, h, tile));
-        warm!(format!("gemm_backward_b_{s}_{i}_{h}"), GemmBackwardBKernel::tiled_unrolled(s, i, h, tile));
+        warm!(
+            format!("gemm_backward_a_{s}_{h}_{i}"),
+            GemmBackwardAKernel::tiled_unrolled(s, h, i, tile)
+        );
+        warm!(
+            format!("gemm_backward_b_{s}_{h}_{i}"),
+            GemmBackwardBKernel::tiled_unrolled(s, h, i, tile)
+        );
+        warm!(
+            format!("gemm_backward_a_{s}_{i}_{h}"),
+            GemmBackwardAKernel::tiled_unrolled(s, i, h, tile)
+        );
+        warm!(
+            format!("gemm_backward_b_{s}_{i}_{h}"),
+            GemmBackwardBKernel::tiled_unrolled(s, i, h, tile)
+        );
     }
 
     // ── Activation backward: SiLU ──

--- a/src/autograd/cuda_backward/structured.rs
+++ b/src/autograd/cuda_backward/structured.rs
@@ -131,13 +131,13 @@ pub fn batched_softmax_backward(
     // SAFETY: Kernel launch requires FFI. All buffers are valid GPU allocations with
     // matching sizes, and the kernel parameters match the expected PTX signature.
     unsafe {
-        stream
-            .launch_kernel(module, "batched_softmax_backward", &config, &mut args)
-            .map_err(|e| {
+        stream.launch_kernel(module, "batched_softmax_backward", &config, &mut args).map_err(
+            |e| {
                 CudaTensorError::KernelError(format!(
                     "Batched softmax backward launch failed: {e:?}"
                 ))
-            })?;
+            },
+        )?;
     }
 
     Ok(())
@@ -208,11 +208,9 @@ pub fn rms_norm_backward(
     // SAFETY: Kernel launch requires FFI. All buffers are valid GPU allocations with
     // matching sizes, and the kernel parameters match the expected PTX signature.
     unsafe {
-        stream
-            .launch_kernel(module, "batched_rms_norm_backward", &config, &mut args)
-            .map_err(|e| {
-                CudaTensorError::KernelError(format!("RMSNorm backward launch failed: {e:?}"))
-            })?;
+        stream.launch_kernel(module, "batched_rms_norm_backward", &config, &mut args).map_err(
+            |e| CudaTensorError::KernelError(format!("RMSNorm backward launch failed: {e:?}")),
+        )?;
     }
 
     Ok(())
@@ -276,11 +274,9 @@ pub fn rms_norm_forward(
     // output has batch_size * hidden_size elements, gamma has hidden_size elements.
     // Parameters match PTX signature (u64 input_ptr, u64 output_ptr, u64 gamma_ptr).
     unsafe {
-        stream
-            .launch_kernel(module, "batched_rmsnorm_vectorized", &config, &mut args)
-            .map_err(|e| {
-                CudaTensorError::KernelError(format!("RMSNorm forward launch failed: {e:?}"))
-            })?;
+        stream.launch_kernel(module, "batched_rmsnorm_vectorized", &config, &mut args).map_err(
+            |e| CudaTensorError::KernelError(format!("RMSNorm forward launch failed: {e:?}")),
+        )?;
     }
 
     Ok(())

--- a/src/autograd/cuda_backward/tests/structured.rs
+++ b/src/autograd/cuda_backward/tests/structured.rs
@@ -252,10 +252,9 @@ fn rms_norm_backward_cpu(
         let variance_eps = mean_sq + eps;
         let rms = variance_eps.sqrt();
 
-        let mean_xgg: f32 = (0..hidden_size)
-            .map(|i| row[i] * grad_output[base + i] * gamma[i])
-            .sum::<f32>()
-            / hidden_size as f32;
+        let mean_xgg: f32 =
+            (0..hidden_size).map(|i| row[i] * grad_output[base + i] * gamma[i]).sum::<f32>()
+                / hidden_size as f32;
 
         for i in 0..hidden_size {
             let adjust = row[i] / variance_eps * mean_xgg;
@@ -295,8 +294,15 @@ fn test_rms_norm_backward_finite_difference_small() {
         GpuBuffer::from_host(&ctx, &vec![0.0f32; hidden_size]).expect("upload");
 
     rms_norm_backward(
-        &input_gpu, &gamma_gpu, &grad_out_gpu, &mut grad_in_gpu, &mut grad_gamma_gpu,
-        num_rows, hidden_size as u32, eps, &stream,
+        &input_gpu,
+        &gamma_gpu,
+        &grad_out_gpu,
+        &mut grad_in_gpu,
+        &mut grad_gamma_gpu,
+        num_rows,
+        hidden_size as u32,
+        eps,
+        &stream,
     )
     .expect("rms_norm_backward");
     stream.synchronize().expect("sync");
@@ -305,7 +311,8 @@ fn test_rms_norm_backward_finite_difference_small() {
     grad_in_gpu.copy_to_host(&mut gpu_grad).expect("download");
 
     // CPU analytical backward
-    let cpu_grad = rms_norm_backward_cpu(&input_data, &gamma_data, &grad_output_data, hidden_size, eps);
+    let cpu_grad =
+        rms_norm_backward_cpu(&input_data, &gamma_data, &grad_output_data, hidden_size, eps);
 
     // Finite-difference numerical gradient
     let h = 1e-3f32;
@@ -327,7 +334,9 @@ fn test_rms_norm_backward_finite_difference_small() {
     for i in 0..n {
         assert!(
             (gpu_grad[i] - cpu_grad[i]).abs() < 1e-3,
-            "GPU vs CPU mismatch at {i}: gpu={}, cpu={}", gpu_grad[i], cpu_grad[i],
+            "GPU vs CPU mismatch at {i}: gpu={}, cpu={}",
+            gpu_grad[i],
+            cpu_grad[i],
         );
     }
 
@@ -335,7 +344,9 @@ fn test_rms_norm_backward_finite_difference_small() {
     for i in 0..n {
         assert!(
             (gpu_grad[i] - fd_grad[i]).abs() < 1e-2,
-            "GPU vs FD mismatch at {i}: gpu={}, fd={}", gpu_grad[i], fd_grad[i],
+            "GPU vs FD mismatch at {i}: gpu={}, fd={}",
+            gpu_grad[i],
+            fd_grad[i],
         );
     }
 }
@@ -372,8 +383,15 @@ fn test_rms_norm_backward_large_hidden() {
         GpuBuffer::from_host(&ctx, &vec![0.0f32; hidden_size]).expect("upload");
 
     rms_norm_backward(
-        &input_gpu, &gamma_gpu, &grad_out_gpu, &mut grad_in_gpu, &mut grad_gamma_gpu,
-        num_rows, hidden_size as u32, eps, &stream,
+        &input_gpu,
+        &gamma_gpu,
+        &grad_out_gpu,
+        &mut grad_in_gpu,
+        &mut grad_gamma_gpu,
+        num_rows,
+        hidden_size as u32,
+        eps,
+        &stream,
     )
     .expect("rms_norm_backward");
     stream.synchronize().expect("sync");
@@ -382,21 +400,14 @@ fn test_rms_norm_backward_large_hidden() {
     grad_in_gpu.copy_to_host(&mut gpu_grad).expect("download");
 
     // CPU analytical reference
-    let cpu_grad = rms_norm_backward_cpu(
-        &input_data, &gamma_data, &grad_output_data, hidden_size, eps,
-    );
+    let cpu_grad =
+        rms_norm_backward_cpu(&input_data, &gamma_data, &grad_output_data, hidden_size, eps);
 
     // Compare GPU vs CPU
-    let max_diff = gpu_grad
-        .iter()
-        .zip(cpu_grad.iter())
-        .map(|(g, c)| (g - c).abs())
-        .fold(0.0f32, f32::max);
+    let max_diff =
+        gpu_grad.iter().zip(cpu_grad.iter()).map(|(g, c)| (g - c).abs()).fold(0.0f32, f32::max);
 
-    assert!(
-        max_diff < 1e-2,
-        "RMSNorm backward hidden=64: max diff {max_diff} exceeds 1e-2"
-    );
+    assert!(max_diff < 1e-2, "RMSNorm backward hidden=64: max diff {max_diff} exceeds 1e-2");
 
     // Finite-difference spot-check (first 8 elements only for speed)
     let h = 1e-3f32;
@@ -413,7 +424,9 @@ fn test_rms_norm_backward_large_hidden() {
 
         assert!(
             (gpu_grad[i] - fd).abs() < 1e-2,
-            "RMSNorm FD check at {i}: gpu={}, fd={}", gpu_grad[i], fd,
+            "RMSNorm FD check at {i}: gpu={}, fd={}",
+            gpu_grad[i],
+            fd,
         );
     }
 }
@@ -455,8 +468,12 @@ fn test_batched_softmax_backward_finite_difference() {
     let mut grad_in_gpu = GpuBuffer::from_host(&ctx, &vec![0.0f32; n]).expect("upload");
 
     batched_softmax_backward(
-        &softmax_gpu, &grad_out_gpu, &mut grad_in_gpu,
-        total_rows, row_size, &stream,
+        &softmax_gpu,
+        &grad_out_gpu,
+        &mut grad_in_gpu,
+        total_rows,
+        row_size,
+        &stream,
     )
     .expect("batched_softmax_backward");
     stream.synchronize().expect("sync");
@@ -472,19 +489,12 @@ fn test_batched_softmax_backward_finite_difference() {
             .map(|i| softmax_data[base + i] * grad_output_data[base + i])
             .sum();
         for i in 0..row_size as usize {
-            cpu_grad[base + i] =
-                softmax_data[base + i] * (grad_output_data[base + i] - dot);
+            cpu_grad[base + i] = softmax_data[base + i] * (grad_output_data[base + i] - dot);
         }
     }
 
-    let max_diff = gpu_grad
-        .iter()
-        .zip(cpu_grad.iter())
-        .map(|(g, c)| (g - c).abs())
-        .fold(0.0f32, f32::max);
+    let max_diff =
+        gpu_grad.iter().zip(cpu_grad.iter()).map(|(g, c)| (g - c).abs()).fold(0.0f32, f32::max);
 
-    assert!(
-        max_diff < 1e-3,
-        "Batched softmax backward: max diff {max_diff} exceeds 1e-3"
-    );
+    assert!(max_diff < 1e-3, "Batched softmax backward: max diff {max_diff} exceeds 1e-3");
 }

--- a/src/autograd/cuda_forward/activations.rs
+++ b/src/autograd/cuda_forward/activations.rs
@@ -263,9 +263,7 @@ pub fn batched_softmax_forward(
     // matching sizes, and the kernel parameters match the expected PTX signature.
     unsafe {
         stream.launch_kernel(module, kernel_name, &config, &mut args).map_err(|e| {
-            CudaTensorError::KernelError(format!(
-                "Batched softmax forward launch failed: {e:?}"
-            ))
+            CudaTensorError::KernelError(format!("Batched softmax forward launch failed: {e:?}"))
         })?;
     }
 

--- a/src/autograd/cuda_forward/bf16_cast.rs
+++ b/src/autograd/cuda_forward/bf16_cast.rs
@@ -144,11 +144,8 @@ pub fn cast_f32_to_bf16_gpu(
     let src_ptr = src.as_ptr();
     let dst_ptr = dst.as_ptr();
 
-    let mut args: [*mut std::ffi::c_void; 3] = [
-        &src_ptr as *const _ as *mut _,
-        &dst_ptr as *const _ as *mut _,
-        &n as *const _ as *mut _,
-    ];
+    let mut args: [*mut std::ffi::c_void; 3] =
+        [&src_ptr as *const _ as *mut _, &dst_ptr as *const _ as *mut _, &n as *const _ as *mut _];
 
     // SAFETY: Kernel launch requires FFI. src and dst are valid GPU allocations,
     // src has n*4 bytes readable, dst has n*2 bytes writable.
@@ -194,11 +191,8 @@ pub fn cast_bf16_to_f32_gpu(
     let src_ptr = src.as_ptr();
     let dst_ptr = dst.as_ptr();
 
-    let mut args: [*mut std::ffi::c_void; 3] = [
-        &src_ptr as *const _ as *mut _,
-        &dst_ptr as *const _ as *mut _,
-        &n as *const _ as *mut _,
-    ];
+    let mut args: [*mut std::ffi::c_void; 3] =
+        [&src_ptr as *const _ as *mut _, &dst_ptr as *const _ as *mut _, &n as *const _ as *mut _];
 
     // SAFETY: src and dst are valid GPU allocations, src has n*2 bytes, dst has n*4 bytes.
     unsafe {

--- a/src/autograd/cuda_forward/cache.rs
+++ b/src/autograd/cuda_forward/cache.rs
@@ -12,10 +12,9 @@ use std::sync::{Mutex, OnceLock};
 use trueno_gpu::driver::{CudaContext, CudaModule};
 #[cfg(feature = "cuda")]
 use trueno_gpu::kernels::{
-    Batched4DGemmKernel, BatchedSoftmaxKernel, BatchedToInterleavedKernel,
-    BatchedTransposeKernel, ElementwiseMulKernel, FusedSwigluKernel, GemmKernel,
-    InterleavedToBatchedKernel, Kernel, Nf4GemmKernel,
-    ResidualAddKernel, RmsNormKernel, ScaleKernel, SiluKernel,
+    Batched4DGemmKernel, BatchedSoftmaxKernel, BatchedToInterleavedKernel, BatchedTransposeKernel,
+    ElementwiseMulKernel, FusedSwigluKernel, GemmKernel, InterleavedToBatchedKernel, Kernel,
+    Nf4GemmKernel, ResidualAddKernel, RmsNormKernel, ScaleKernel, SiluKernel,
 };
 
 use crate::autograd::cuda_tensor::{CudaTensorError, Result};
@@ -128,8 +127,8 @@ impl ForwardKernelCache {
         let nh = num_heads as u32;
         let nkv = num_kv_heads as u32;
         let hd = head_dim as u32;
-        let sh = s * h;   // seq_len * hidden_size
-        let si = s * i;   // seq_len * intermediate_size
+        let sh = s * h; // seq_len * hidden_size
+        let si = s * i; // seq_len * intermediate_size
 
         let mut count = 0u32;
         let target = self.sm_target.clone();
@@ -179,16 +178,10 @@ impl ForwardKernelCache {
         }
 
         // 9. Batched transpose: K^T (NH, S, HD)
-        warm!(
-            format!("batched_transpose_{nh}_{s}_{hd}"),
-            BatchedTransposeKernel::new(nh, s, hd)
-        );
+        warm!(format!("batched_transpose_{nh}_{s}_{hd}"), BatchedTransposeKernel::new(nh, s, hd));
 
         // 9b. Batched transpose: backward reverse (NH, HD, S)
-        warm!(
-            format!("batched_transpose_{nh}_{hd}_{s}"),
-            BatchedTransposeKernel::new(nh, hd, s)
-        );
+        warm!(format!("batched_transpose_{nh}_{hd}_{s}"), BatchedTransposeKernel::new(nh, hd, s));
 
         // 10. Batched 4D GEMM: Q@K^T (1, NH, S, S, HD)
         warm!(
@@ -350,9 +343,7 @@ pub fn pre_warm_forward_kernels(
     head_dim: usize,
     max_seq_len: usize,
 ) -> Result<()> {
-    let cache = FORWARD_KERNEL_CACHE
-        .get()
-        .ok_or(CudaTensorError::DeviceNotInitialized)?;
+    let cache = FORWARD_KERNEL_CACHE.get().ok_or(CudaTensorError::DeviceNotInitialized)?;
     let mut cache = cache.lock().map_err(|_err| {
         CudaTensorError::KernelError("Failed to acquire kernel cache lock".to_string())
     })?;
@@ -378,17 +369,9 @@ pub fn pre_warm_lora_backward_kernels(
     max_seq_len: usize,
     lora_rank: usize,
 ) -> Result<()> {
-    let cache = FORWARD_KERNEL_CACHE
-        .get()
-        .ok_or(CudaTensorError::DeviceNotInitialized)?;
+    let cache = FORWARD_KERNEL_CACHE.get().ok_or(CudaTensorError::DeviceNotInitialized)?;
     let mut cache = cache.lock().map_err(|_err| {
         CudaTensorError::KernelError("Failed to acquire kernel cache lock".to_string())
     })?;
-    cache.pre_warm_lora_backward(
-        hidden_size,
-        q_dim,
-        kv_hidden_size,
-        max_seq_len,
-        lora_rank,
-    )
+    cache.pre_warm_lora_backward(hidden_size, q_dim, kv_hidden_size, max_seq_len, lora_rank)
 }

--- a/src/autograd/cuda_forward/elementwise.rs
+++ b/src/autograd/cuda_forward/elementwise.rs
@@ -121,9 +121,7 @@ pub fn elementwise_mul_forward(
     // matching sizes, and the kernel parameters match the expected PTX signature.
     unsafe {
         stream.launch_kernel(module, "elementwise_mul", &config, &mut args).map_err(|e| {
-            CudaTensorError::KernelError(format!(
-                "Elementwise mul forward launch failed: {e:?}"
-            ))
+            CudaTensorError::KernelError(format!("Elementwise mul forward launch failed: {e:?}"))
         })?;
     }
 
@@ -227,20 +225,16 @@ pub fn interleaved_to_batched_forward(
     let input_ptr = input.as_ptr();
     let output_ptr = output.as_ptr();
 
-    let mut args: [*mut std::ffi::c_void; 2] = [
-        &input_ptr as *const _ as *mut _,
-        &output_ptr as *const _ as *mut _,
-    ];
+    let mut args: [*mut std::ffi::c_void; 2] =
+        [&input_ptr as *const _ as *mut _, &output_ptr as *const _ as *mut _];
 
     // SAFETY: Kernel launch requires FFI. All buffers are valid GPU allocations.
     unsafe {
-        stream
-            .launch_kernel(module, "interleaved_to_batched", &config, &mut args)
-            .map_err(|e| {
-                CudaTensorError::KernelError(format!(
-                    "Interleaved-to-batched launch failed: {e:?}"
-                ))
-            })?;
+        stream.launch_kernel(module, "interleaved_to_batched", &config, &mut args).map_err(
+            |e| {
+                CudaTensorError::KernelError(format!("Interleaved-to-batched launch failed: {e:?}"))
+            },
+        )?;
     }
 
     Ok(())
@@ -352,20 +346,16 @@ pub fn batched_to_interleaved_forward(
     let input_ptr = input.as_ptr();
     let output_ptr = output.as_ptr();
 
-    let mut args: [*mut std::ffi::c_void; 2] = [
-        &input_ptr as *const _ as *mut _,
-        &output_ptr as *const _ as *mut _,
-    ];
+    let mut args: [*mut std::ffi::c_void; 2] =
+        [&input_ptr as *const _ as *mut _, &output_ptr as *const _ as *mut _];
 
     // SAFETY: Kernel launch requires FFI. All buffers are valid GPU allocations.
     unsafe {
-        stream
-            .launch_kernel(module, "batched_to_interleaved", &config, &mut args)
-            .map_err(|e| {
-                CudaTensorError::KernelError(format!(
-                    "Batched-to-interleaved launch failed: {e:?}"
-                ))
-            })?;
+        stream.launch_kernel(module, "batched_to_interleaved", &config, &mut args).map_err(
+            |e| {
+                CudaTensorError::KernelError(format!("Batched-to-interleaved launch failed: {e:?}"))
+            },
+        )?;
     }
 
     Ok(())

--- a/src/autograd/cuda_forward/matmul.rs
+++ b/src/autograd/cuda_forward/matmul.rs
@@ -6,7 +6,9 @@
 #[cfg(feature = "cuda")]
 use trueno_gpu::driver::{CudaStream, GpuBuffer, LaunchConfig};
 #[cfg(feature = "cuda")]
-use trueno_gpu::kernels::{Batched4DGemmKernel, FusedSwigluKernel, GemmKernel, Kernel, Nf4GemmKernel};
+use trueno_gpu::kernels::{
+    Batched4DGemmKernel, FusedSwigluKernel, GemmKernel, Kernel, Nf4GemmKernel,
+};
 
 use crate::autograd::cuda_tensor::{CudaTensorError, Result};
 

--- a/src/autograd/cuda_forward/mod.rs
+++ b/src/autograd/cuda_forward/mod.rs
@@ -39,15 +39,20 @@ mod tests;
 pub use activations::{
     batched_softmax_forward, gelu_forward, relu_forward, silu_forward, softmax_forward,
 };
-pub use cache::{init_forward_kernel_cache, pre_warm_forward_kernels, pre_warm_lora_backward_kernels};
+pub use bf16_cast::{bf16_slice_to_f32, f32_slice_to_bf16};
+#[cfg(feature = "cuda")]
+pub use bf16_cast::{cast_bf16_to_f32_gpu, cast_f32_to_bf16_gpu};
+pub use cache::{
+    init_forward_kernel_cache, pre_warm_forward_kernels, pre_warm_lora_backward_kernels,
+};
 pub use elementwise::{
     batched_to_interleaved_forward, batched_transpose_forward, elementwise_mul_forward,
     expand_kv_heads, interleaved_to_batched_forward, residual_add_forward, scale_forward,
 };
-pub use matmul::{batched_4d_gemm_forward, fused_swiglu_forward, gemm_forward, gemm_nf4_backward_a, gemm_nf4_forward};
 #[cfg(feature = "cuda")]
 pub use matmul::gemm_forward_bf16;
-pub use bf16_cast::{bf16_slice_to_f32, f32_slice_to_bf16};
-#[cfg(feature = "cuda")]
-pub use bf16_cast::{cast_bf16_to_f32_gpu, cast_f32_to_bf16_gpu};
+pub use matmul::{
+    batched_4d_gemm_forward, fused_swiglu_forward, gemm_forward, gemm_nf4_backward_a,
+    gemm_nf4_forward,
+};
 pub use normalization::{layer_norm_forward, rms_norm_forward};

--- a/src/autograd/cuda_forward/tests/test_elementwise.rs
+++ b/src/autograd/cuda_forward/tests/test_elementwise.rs
@@ -29,8 +29,7 @@ fn test_contract_residual_add_gpu_equals_cpu() {
     let b = GpuBuffer::from_host(&ctx, &b_data).expect("operation should succeed");
     let mut output = GpuBuffer::new(&ctx, n).expect("operation should succeed");
 
-    residual_add_forward(&a, &b, &mut output, n as u32, &stream)
-        .expect("operation should succeed");
+    residual_add_forward(&a, &b, &mut output, n as u32, &stream).expect("operation should succeed");
     stream.synchronize().expect("operation should succeed");
 
     let mut result = vec![0.0f32; n];
@@ -68,18 +67,14 @@ fn test_contract_residual_add_large() {
     let b = GpuBuffer::from_host(&ctx, &b_data).expect("operation should succeed");
     let mut output = GpuBuffer::new(&ctx, n).expect("operation should succeed");
 
-    residual_add_forward(&a, &b, &mut output, n as u32, &stream)
-        .expect("operation should succeed");
+    residual_add_forward(&a, &b, &mut output, n as u32, &stream).expect("operation should succeed");
     stream.synchronize().expect("operation should succeed");
 
     let mut result = vec![0.0f32; n];
     output.copy_to_host(&mut result).expect("operation should succeed");
 
-    let max_err: f32 = result
-        .iter()
-        .zip(expected.iter())
-        .map(|(g, e)| (g - e).abs())
-        .fold(0.0f32, f32::max);
+    let max_err: f32 =
+        result.iter().zip(expected.iter()).map(|(g, e)| (g - e).abs()).fold(0.0f32, f32::max);
     assert!(max_err < 1e-5, "residual_add large max error: {max_err}");
 }
 
@@ -161,10 +156,7 @@ fn test_contract_scale_gpu_equals_cpu() {
     output.copy_to_host(&mut result).expect("operation should succeed");
 
     for (i, (&got, &exp)) in result.iter().zip(expected.iter()).enumerate() {
-        assert!(
-            (got - exp).abs() < 1e-6,
-            "scale mismatch at {i}: got {got}, expected {exp}"
-        );
+        assert!((got - exp).abs() < 1e-6, "scale mismatch at {i}: got {got}, expected {exp}");
     }
 }
 
@@ -325,10 +317,7 @@ fn test_contract_batched_to_interleaved_roundtrip() {
     roundtrip.copy_to_host(&mut result).expect("operation should succeed");
 
     for (i, (&got, &exp)) in result.iter().zip(original.iter()).enumerate() {
-        assert!(
-            (got - exp).abs() < 1e-6,
-            "roundtrip mismatch at {i}: got {got}, expected {exp}"
-        );
+        assert!((got - exp).abs() < 1e-6, "roundtrip mismatch at {i}: got {got}, expected {exp}");
     }
 }
 
@@ -372,7 +361,8 @@ fn test_contract_expand_kv_heads() {
     ];
 
     let src = GpuBuffer::from_host(&ctx, &src_data).expect("operation should succeed");
-    let mut dst = GpuBuffer::new(&ctx, num_heads * elems_per_head).expect("operation should succeed");
+    let mut dst =
+        GpuBuffer::new(&ctx, num_heads * elems_per_head).expect("operation should succeed");
 
     expand_kv_heads(&src, &mut dst, num_kv_heads, heads_per_kv, elems_per_head, &stream)
         .expect("operation should succeed");
@@ -539,10 +529,7 @@ fn test_contract_batched_softmax_rows_sum_to_one() {
     for r in 0..total_rows as usize {
         let row_start = r * row_size as usize;
         let row_sum: f32 = result[row_start..row_start + row_size as usize].iter().sum();
-        assert!(
-            (row_sum - 1.0).abs() < 1e-4,
-            "softmax row {r} sums to {row_sum}, expected 1.0"
-        );
+        assert!((row_sum - 1.0).abs() < 1e-4, "softmax row {r} sums to {row_sum}, expected 1.0");
 
         // All values should be positive
         for j in 0..row_size as usize {
@@ -646,7 +633,8 @@ fn test_contract_attention_pipeline_layout_roundtrip() {
     let mut batched = GpuBuffer::new(&ctx, total).expect("operation should succeed");
     let mut transposed = GpuBuffer::new(&ctx, total).expect("operation should succeed");
     let mut transposed_back = GpuBuffer::new(&ctx, total).expect("operation should succeed");
-    let _batched_back: GpuBuffer<f32> = GpuBuffer::new(&ctx, total).expect("operation should succeed");
+    let _batched_back: GpuBuffer<f32> =
+        GpuBuffer::new(&ctx, total).expect("operation should succeed");
     let mut roundtrip = GpuBuffer::new(&ctx, total).expect("operation should succeed");
 
     // interleaved → batched [n_heads, seq, head_dim]
@@ -673,9 +661,7 @@ fn test_contract_attention_pipeline_layout_roundtrip() {
     let mut batched_data = vec![0.0f32; total];
     let mut transposed_back_data = vec![0.0f32; total];
     batched.copy_to_host(&mut batched_data).expect("operation should succeed");
-    transposed_back
-        .copy_to_host(&mut transposed_back_data)
-        .expect("operation should succeed");
+    transposed_back.copy_to_host(&mut transposed_back_data).expect("operation should succeed");
 
     for (i, (&got, &exp)) in transposed_back_data.iter().zip(batched_data.iter()).enumerate() {
         assert!(

--- a/src/autograd/cuda_forward/tests/test_matmul.rs
+++ b/src/autograd/cuda_forward/tests/test_matmul.rs
@@ -422,7 +422,8 @@ fn test_gemm_forward_bf16_precision_matches_reference() {
 
     let a = GpuBuffer::from_host(&ctx, &a_data).expect("operation should succeed");
     let b = GpuBuffer::from_host(&ctx, &b_data).expect("operation should succeed");
-    let mut c = GpuBuffer::from_host(&ctx, &vec![0.0f32; (m * n) as usize]).expect("operation should succeed");
+    let mut c = GpuBuffer::from_host(&ctx, &vec![0.0f32; (m * n) as usize])
+        .expect("operation should succeed");
 
     gemm_forward_bf16(&a, &b, &mut c, m, k, n, &stream).expect("operation should succeed");
     stream.synchronize().expect("operation should succeed");

--- a/src/autograd/cuda_optim.rs
+++ b/src/autograd/cuda_optim.rs
@@ -130,15 +130,15 @@ pub fn pre_warm_lora_adamw_kernels(
     let mut sizes: Vec<u32> = Vec::new();
 
     // LoRA parameter sizes (always needed)
-    sizes.push((hidden_size * lora_rank) as u32);    // A_q, A_v
-    sizes.push((lora_rank * q_dim) as u32);          // B_q
+    sizes.push((hidden_size * lora_rank) as u32); // A_q, A_v
+    sizes.push((lora_rank * q_dim) as u32); // B_q
     sizes.push((lora_rank * kv_hidden_size) as u32); // B_v
-    sizes.push(hidden_size as u32);                   // norm weights
+    sizes.push(hidden_size as u32); // norm weights
 
     // Full fp32 weight sizes (non-NF4 mode: optimizer runs on all block weights)
     if !quantize_nf4 {
-        sizes.push((hidden_size * hidden_size) as u32);       // w_q, w_o
-        sizes.push((hidden_size * kv_hidden_size) as u32);    // w_k, w_v
+        sizes.push((hidden_size * hidden_size) as u32); // w_q, w_o
+        sizes.push((hidden_size * kv_hidden_size) as u32); // w_k, w_v
         sizes.push((hidden_size * intermediate_size) as u32); // w_gate, w_up, w_down
     }
 
@@ -392,15 +392,11 @@ pub fn gradient_clip_cuda(
 ///
 /// Returns `Err` if kernel cache not initialized, kernel compilation fails, or GPU transfer fails.
 #[cfg(feature = "cuda")]
-pub fn squared_sum_cuda(
-    input: &GpuBuffer<f32>,
-    n: u32,
-    stream: &CudaStream,
-) -> Result<f32> {
+pub fn squared_sum_cuda(input: &GpuBuffer<f32>, n: u32, stream: &CudaStream) -> Result<f32> {
     let pending = squared_sum_launch_cuda(input, n, stream)?;
-    stream.synchronize().map_err(|e| {
-        CudaTensorError::KernelError(format!("Stream sync failed: {e:?}"))
-    })?;
+    stream
+        .synchronize()
+        .map_err(|e| CudaTensorError::KernelError(format!("Stream sync failed: {e:?}")))?;
     squared_sum_collect(&pending)
 }
 
@@ -545,9 +541,8 @@ pub fn fused_cross_entropy_cuda(
 
     // Upload targets to GPU (seq_len × u32 = ~512 bytes for seq_len=128)
     let targets_u32: Vec<u32> = target_ids[..seq_len as usize].to_vec();
-    let targets_gpu = GpuBuffer::<u32>::from_host(&ctx, &targets_u32).map_err(|e| {
-        CudaTensorError::KernelError(format!("Failed to upload targets: {e:?}"))
-    })?;
+    let targets_gpu = GpuBuffer::<u32>::from_host(&ctx, &targets_u32)
+        .map_err(|e| CudaTensorError::KernelError(format!("Failed to upload targets: {e:?}")))?;
 
     // KAIZEN-052: No grad_gpu allocation — gradient written in-place to logits_buf.
 
@@ -557,11 +552,8 @@ pub fn fused_cross_entropy_cuda(
     })?;
 
     // Shared memory: 72 bytes (8 warp maxes + global max + 8 warp sums + global sum)
-    let config = LaunchConfig {
-        grid: (seq_len, 1, 1),
-        block: (kernel.block_size(), 1, 1),
-        shared_mem: 72,
-    };
+    let config =
+        LaunchConfig { grid: (seq_len, 1, 1), block: (kernel.block_size(), 1, 1), shared_mem: 72 };
 
     let logits_grad_ptr = logits_buf.as_ptr();
     let targets_ptr = targets_gpu.as_ptr();
@@ -586,9 +578,9 @@ pub fn fused_cross_entropy_cuda(
     }
 
     // Synchronize and download loss partials (~512 bytes)
-    stream.synchronize().map_err(|e| {
-        CudaTensorError::KernelError(format!("Stream sync failed: {e:?}"))
-    })?;
+    stream
+        .synchronize()
+        .map_err(|e| CudaTensorError::KernelError(format!("Stream sync failed: {e:?}")))?;
 
     let mut loss_partials = vec![0.0f32; seq_len as usize];
     loss_gpu.copy_to_host(&mut loss_partials).map_err(|e| {
@@ -648,9 +640,8 @@ pub fn fused_causal_cross_entropy_cuda(
 
     // Upload targets to GPU (seq_len × u32 = ~2KB for seq_len=512)
     let targets_u32: Vec<u32> = target_ids[..seq_len as usize].to_vec();
-    let targets_gpu = GpuBuffer::<u32>::from_host(&ctx, &targets_u32).map_err(|e| {
-        CudaTensorError::KernelError(format!("Failed to upload targets: {e:?}"))
-    })?;
+    let targets_gpu = GpuBuffer::<u32>::from_host(&ctx, &targets_u32)
+        .map_err(|e| CudaTensorError::KernelError(format!("Failed to upload targets: {e:?}")))?;
 
     // Allocate loss partials buffer (seq_len × f32)
     let loss_gpu = GpuBuffer::<f32>::new(&ctx, seq_len as usize).map_err(|e| {
@@ -658,11 +649,8 @@ pub fn fused_causal_cross_entropy_cuda(
     })?;
 
     // Shared memory: 72 bytes (same as base kernel)
-    let config = LaunchConfig {
-        grid: (seq_len, 1, 1),
-        block: (kernel.block_size(), 1, 1),
-        shared_mem: 72,
-    };
+    let config =
+        LaunchConfig { grid: (seq_len, 1, 1), block: (kernel.block_size(), 1, 1), shared_mem: 72 };
 
     let logits_grad_ptr = logits_buf.as_ptr();
     let targets_ptr = targets_gpu.as_ptr();
@@ -683,15 +671,19 @@ pub fn fused_causal_cross_entropy_cuda(
     // elements. loss_gpu has seq_len f32 elements. Parameters match PTX signature.
     // Positions outside [loss_start, loss_end) get zero gradient and zero loss.
     unsafe {
-        stream.launch_kernel(module, "fused_causal_cross_entropy", &config, &mut args).map_err(|e| {
-            CudaTensorError::KernelError(format!("Fused causal cross-entropy launch failed: {e:?}"))
-        })?;
+        stream.launch_kernel(module, "fused_causal_cross_entropy", &config, &mut args).map_err(
+            |e| {
+                CudaTensorError::KernelError(format!(
+                    "Fused causal cross-entropy launch failed: {e:?}"
+                ))
+            },
+        )?;
     }
 
     // Synchronize and download loss partials (~2KB)
-    stream.synchronize().map_err(|e| {
-        CudaTensorError::KernelError(format!("Stream sync failed: {e:?}"))
-    })?;
+    stream
+        .synchronize()
+        .map_err(|e| CudaTensorError::KernelError(format!("Stream sync failed: {e:?}")))?;
 
     let mut loss_partials = vec![0.0f32; seq_len as usize];
     loss_gpu.copy_to_host(&mut loss_partials).map_err(|e| {
@@ -703,10 +695,8 @@ pub fn fused_causal_cross_entropy_cuda(
     if num_loss_tokens == 0 {
         return Ok(0.0);
     }
-    let total_loss: f64 = loss_partials[loss_start as usize..loss_end as usize]
-        .iter()
-        .map(|&x| f64::from(x))
-        .sum();
+    let total_loss: f64 =
+        loss_partials[loss_start as usize..loss_end as usize].iter().map(|&x| f64::from(x)).sum();
     let avg_loss = (total_loss / num_loss_tokens as f64) as f32;
 
     Ok(avg_loss)

--- a/src/autograd/ops/correctness_tests.rs
+++ b/src/autograd/ops/correctness_tests.rs
@@ -3,8 +3,8 @@
 //!
 //! Batuta: NR-14 (Normalization Layer Correctness)
 
-use crate::autograd::Tensor;
 use super::layer_norm;
+use crate::autograd::Tensor;
 
 /// Reference LayerNorm (f64 precision)
 fn reference_layer_norm_f64(x: &[f32], gamma: &[f32], beta: &[f32], eps: f32) -> Vec<f32> {
@@ -54,7 +54,7 @@ fn norm_test_variance_one() {
     let beta = Tensor::from_vec(vec![0.0; 5], false);
     let result = layer_norm(&x, &gamma, &beta, 1e-5);
     let mean: f32 = result.data().iter().sum::<f32>() / result.len() as f32;
-    let variance: f32 = result.data().iter().map(|&v| (v - mean) * (v - mean)).sum::<f32>()
-        / result.len() as f32;
+    let variance: f32 =
+        result.data().iter().map(|&v| (v - mean) * (v - mean)).sum::<f32>() / result.len() as f32;
     assert!((variance - 1.0).abs() < 1e-4, "Output variance should be ~1, got {variance}");
 }

--- a/src/autograd/ops/matmul.rs
+++ b/src/autograd/ops/matmul.rs
@@ -175,9 +175,7 @@ pub fn matmul_compute(a: &[f32], b: &[f32], m: usize, k: usize, n: usize) -> Vec
     // wgpu GPU fallback (AMD/Intel/Apple GPUs via Vulkan/Metal/DX12)
     // KAIZEN-004: Skip per-op wgpu when batched forward pass is active
     #[cfg(feature = "gpu")]
-    if !WGPU_BATCH_MODE.load(std::sync::atomic::Ordering::Relaxed)
-        && m * k * n > 32_768
-    {
+    if !WGPU_BATCH_MODE.load(std::sync::atomic::Ordering::Relaxed) && m * k * n > 32_768 {
         if let Some(result) = wgpu_matmul(a, b, m, k, n) {
             return result;
         }
@@ -228,31 +226,31 @@ pub fn pre_warm_realizador_gemm(
 
     let mut shapes: Vec<(usize, usize, usize)> = vec![
         // Forward linear projections
-        (s, h, h),   // Q, O projections
-        (s, h, kv),  // K, V projections
-        (s, h, i),   // FFN gate, up
-        (s, i, h),   // FFN down
+        (s, h, h),  // Q, O projections
+        (s, h, kv), // K, V projections
+        (s, h, i),  // FFN gate, up
+        (s, i, h),  // FFN down
         // LoRA forward
-        (s, h, r),   // LoRA A (Q/O/gate/up)
-        (s, r, h),   // LoRA B (Q/O)
-        (s, kv, r),  // LoRA A (K/V) — if kv != h
-        (s, r, kv),  // LoRA B (K/V)
+        (s, h, r),  // LoRA A (Q/O/gate/up)
+        (s, r, h),  // LoRA B (Q/O)
+        (s, kv, r), // LoRA A (K/V) — if kv != h
+        (s, r, kv), // LoRA B (K/V)
         // Backward: grad_A = grad_C @ B^T → (M, N_fwd, K_fwd)
         // For (s,h,h): grad_A is (s,h,h) — same
-        (s, kv, h),  // K/V backward grad_A: (s, kv) @ (kv, h)
-        (s, i, h),   // Gate/Up backward grad_A — same as FFN down forward
-        (s, h, i),   // Down backward grad_A — same as FFN gate forward
+        (s, kv, h), // K/V backward grad_A: (s, kv) @ (kv, h)
+        (s, i, h),  // Gate/Up backward grad_A — same as FFN down forward
+        (s, h, i),  // Down backward grad_A — same as FFN gate forward
         // Backward: grad_B = A^T @ grad_C → (K_fwd, M, N_fwd)
-        (h, s, h),   // Q/O backward grad_B: (h, s) @ (s, h)
-        (h, s, kv),  // K/V backward grad_B: (h, s) @ (s, kv)
-        (h, s, i),   // Gate/Up backward grad_B: (h, s) @ (s, i)
-        (i, s, h),   // Down backward grad_B: (i, s) @ (s, h)
+        (h, s, h),  // Q/O backward grad_B: (h, s) @ (s, h)
+        (h, s, kv), // K/V backward grad_B: (h, s) @ (s, kv)
+        (h, s, i),  // Gate/Up backward grad_B: (h, s) @ (s, i)
+        (i, s, h),  // Down backward grad_B: (i, s) @ (s, h)
         // LoRA backward
-        (s, r, h),   // LoRA A backward grad_A — same as LoRA B forward
-        (h, s, r),   // LoRA A backward grad_B
-        (s, h, r),   // LoRA B backward grad_A — same as LoRA A forward
-        (r, s, h),   // LoRA B backward grad_B
-        (r, s, kv),  // LoRA B (K/V) backward grad_B
+        (s, r, h),  // LoRA A backward grad_A — same as LoRA B forward
+        (h, s, r),  // LoRA A backward grad_B
+        (s, h, r),  // LoRA B backward grad_A — same as LoRA A forward
+        (r, s, h),  // LoRA B backward grad_B
+        (r, s, kv), // LoRA B (K/V) backward grad_B
         // Classifier head
         (1, h, num_classes),
     ];
@@ -270,9 +268,7 @@ pub fn pre_warm_realizador_gemm(
         match cuda_matmul(&mut executor, &a, &b, m, k, n) {
             Ok(_) => warmed += 1,
             Err(e) => {
-                eprintln!(
-                    "[CUDA] realizador GEMM pre-warm failed for ({m},{k},{n}): {e}"
-                );
+                eprintln!("[CUDA] realizador GEMM pre-warm failed for ({m},{k},{n}): {e}");
             }
         }
     }
@@ -358,9 +354,7 @@ pub fn matmul_compute(a: &[f32], b: &[f32], m: usize, k: usize, n: usize) -> Vec
     {
         // KAIZEN-004: Skip per-op wgpu when batched forward pass is active.
         // Attention matmuls use CPU SIMD instead — equally fast, no buffer overhead.
-        if !WGPU_BATCH_MODE.load(std::sync::atomic::Ordering::Relaxed)
-            && m * k * n > 32_768
-        {
+        if !WGPU_BATCH_MODE.load(std::sync::atomic::Ordering::Relaxed) && m * k * n > 32_768 {
             if let Some(result) = wgpu_matmul(a, b, m, k, n) {
                 return result;
             }
@@ -545,8 +539,24 @@ impl BackwardOp for MatmulBackward {
 /// - `∂L/∂A = ∂L/∂C @ B`  — (M,N) @ (N,K) = (M,K)
 /// - `∂L/∂B = ∂L/∂C^T @ A` — (N,M) @ (M,K) = (N,K)
 pub fn matmul_nt(a: &Tensor, b: &Tensor, m: usize, k: usize, n: usize) -> Tensor {
-    assert_eq!(a.len(), m * k, "Matrix A size mismatch: expected {}×{} = {}, got {}", m, k, m * k, a.len());
-    assert_eq!(b.len(), n * k, "Matrix B size mismatch: expected {}×{} = {}, got {}", n, k, n * k, b.len());
+    assert_eq!(
+        a.len(),
+        m * k,
+        "Matrix A size mismatch: expected {}×{} = {}, got {}",
+        m,
+        k,
+        m * k,
+        a.len()
+    );
+    assert_eq!(
+        b.len(),
+        n * k,
+        "Matrix B size mismatch: expected {}×{} = {}, got {}",
+        n,
+        k,
+        n * k,
+        b.len()
+    );
 
     let a_slice = a.data();
     let b_slice = b.data();
@@ -911,7 +921,7 @@ mod tests {
     fn test_matmul_nt_backward_grad_flows_to_b() {
         // KAIZEN-011: Verify gradients flow to the ORIGINAL B tensor (not a copy)
         let a = Tensor::new(Array1::from(vec![1.0, 2.0, 3.0, 4.0]), false); // 2x2
-        let b = Tensor::new(Array1::from(vec![5.0, 6.0, 7.0, 8.0]), true);  // 2x2, requires_grad
+        let b = Tensor::new(Array1::from(vec![5.0, 6.0, 7.0, 8.0]), true); // 2x2, requires_grad
 
         let c = matmul_nt(&a, &b, 2, 2, 2);
         assert!(c.requires_grad());
@@ -928,10 +938,7 @@ mod tests {
         // = [[1,1],[1,1]] @ [[1,2],[3,4]] = [[4,6],[4,6]]
         let expected_grad_b = vec![4.0, 6.0, 4.0, 6.0];
         for (i, (&got, &exp)) in b_grad.iter().zip(expected_grad_b.iter()).enumerate() {
-            assert!(
-                (got - exp).abs() < 1e-4,
-                "KAIZEN-011: grad_B[{i}] = {got}, expected {exp}"
-            );
+            assert!((got - exp).abs() < 1e-4, "KAIZEN-011: grad_B[{i}] = {got}, expected {exp}");
         }
     }
 
@@ -951,10 +958,7 @@ mod tests {
         // grad_A = grad_C @ B = [[1,1],[1,1]] @ [[5,6],[7,8]] = [[12,14],[12,14]]
         let expected_grad_a = vec![12.0, 14.0, 12.0, 14.0];
         for (i, (&got, &exp)) in a_grad.iter().zip(expected_grad_a.iter()).enumerate() {
-            assert!(
-                (got - exp).abs() < 1e-4,
-                "grad_A[{i}] = {got}, expected {exp}"
-            );
+            assert!((got - exp).abs() < 1e-4, "grad_A[{i}] = {got}, expected {exp}");
         }
     }
 

--- a/src/autograd/ops/mod.rs
+++ b/src/autograd/ops/mod.rs
@@ -5,18 +5,18 @@
 mod activations;
 mod attention;
 mod basic;
-mod matmul;
-mod normalize;
 #[cfg(test)]
 mod correctness_tests;
+mod matmul;
+mod normalize;
 
 // Re-export all public operations
 pub use activations::{gelu, relu, softmax, swish};
 pub use attention::attention;
 pub use basic::{add, add_scaled, mul, scale, sum};
-pub use matmul::{matmul, matmul_compute, matmul_nt, transpose, transpose_tracked};
 #[cfg(feature = "cuda")]
 pub use matmul::pre_warm_realizador_gemm;
+pub use matmul::{matmul, matmul_compute, matmul_nt, transpose, transpose_tracked};
 #[cfg(feature = "gpu")]
 pub use matmul::{suppress_per_op_wgpu, unsuppress_per_op_wgpu};
 pub use normalize::layer_norm;

--- a/src/autograd/ops/normalize.rs
+++ b/src/autograd/ops/normalize.rs
@@ -156,7 +156,10 @@ mod normalization_correctness_tests {
         let result = layer_norm(&x, &gamma, &beta, eps);
         for (i, (&actual, &expected)) in result.data().iter().zip(reference.iter()).enumerate() {
             let diff = (actual - expected).abs();
-            assert!(diff < 1e-5, "LayerNorm correctness[{i}]: actual={actual}, ref={expected}, diff={diff}");
+            assert!(
+                diff < 1e-5,
+                "LayerNorm correctness[{i}]: actual={actual}, ref={expected}, diff={diff}"
+            );
         }
     }
 

--- a/src/autograd/precision/tests.rs
+++ b/src/autograd/precision/tests.rs
@@ -312,10 +312,7 @@ mod tests {
             let bf16 = f32_to_bf16(val);
             let back = bf16_to_f32(bf16);
             let rel_err = (back - val).abs() / val.abs();
-            assert!(
-                rel_err < 0.008,
-                "BF16 relative error {rel_err} too large for {val}"
-            );
+            assert!(rel_err < 0.008, "BF16 relative error {rel_err} too large for {val}");
         }
     }
 
@@ -380,11 +377,7 @@ mod tests {
         let test_values = [0.1, 0.2, 0.3, 1.5, 42.42, -99.99, f32::MAX, f32::MIN_POSITIVE];
         for &val in &test_values {
             let truncated = bf16_truncate(val);
-            assert_eq!(
-                truncated.to_bits() & 0x0000FFFF,
-                0,
-                "lower 16 bits not zeroed for {val}"
-            );
+            assert_eq!(truncated.to_bits() & 0x0000FFFF, 0, "lower 16 bits not zeroed for {val}");
         }
     }
 

--- a/src/autograd/tensor.rs
+++ b/src/autograd/tensor.rs
@@ -26,7 +26,12 @@ pub struct Tensor {
 impl Tensor {
     /// Create a new tensor with data
     pub fn new(data: Array1<f32>, requires_grad: bool) -> Self {
-        Self { data: Rc::new(data), grad: Rc::new(RefCell::new(None)), backward_op: None, requires_grad }
+        Self {
+            data: Rc::new(data),
+            grad: Rc::new(RefCell::new(None)),
+            backward_op: None,
+            requires_grad,
+        }
     }
 
     /// Create a tensor from a vector

--- a/src/cli/commands/experiments.rs
+++ b/src/cli/commands/experiments.rs
@@ -28,9 +28,8 @@ fn list_experiments(
     format: &OutputFormat,
     _log_level: LogLevel,
 ) -> Result<(), String> {
-    let experiments = store
-        .list_experiments()
-        .map_err(|e| format!("Failed to list experiments: {e}"))?;
+    let experiments =
+        store.list_experiments().map_err(|e| format!("Failed to list experiments: {e}"))?;
 
     if experiments.is_empty() {
         eprintln!("No experiments found in {}", store.path());
@@ -61,14 +60,9 @@ fn list_experiments(
     Ok(())
 }
 
-fn show_experiment(
-    store: &SqliteBackend,
-    id: &str,
-    format: &OutputFormat,
-) -> Result<(), String> {
-    let experiment = store
-        .get_experiment(id)
-        .map_err(|e| format!("Failed to get experiment: {e}"))?;
+fn show_experiment(store: &SqliteBackend, id: &str, format: &OutputFormat) -> Result<(), String> {
+    let experiment =
+        store.get_experiment(id).map_err(|e| format!("Failed to get experiment: {e}"))?;
 
     match format {
         OutputFormat::Json => {
@@ -113,9 +107,7 @@ fn list_runs(
     experiment_id: &str,
     format: &OutputFormat,
 ) -> Result<(), String> {
-    let runs = store
-        .list_runs(experiment_id)
-        .map_err(|e| format!("Failed to list runs: {e}"))?;
+    let runs = store.list_runs(experiment_id).map_err(|e| format!("Failed to list runs: {e}"))?;
 
     if runs.is_empty() {
         eprintln!("No runs found for experiment {experiment_id}");
@@ -133,7 +125,8 @@ fn list_runs(
             println!("{}", "-".repeat(80));
             for run in &runs {
                 let end = run
-                    .end_time.map_or_else(|| "-".to_string(), |t| t.format("%Y-%m-%d %H:%M:%S").to_string());
+                    .end_time
+                    .map_or_else(|| "-".to_string(), |t| t.format("%Y-%m-%d %H:%M:%S").to_string());
                 println!(
                     "{:<20} {:<12} {:<24} {:<24}",
                     truncate(&run.id, 18),
@@ -155,9 +148,8 @@ fn show_metrics(
     key: &str,
     format: &OutputFormat,
 ) -> Result<(), String> {
-    let metrics = store
-        .get_metrics(run_id, key)
-        .map_err(|e| format!("Failed to get metrics: {e}"))?;
+    let metrics =
+        store.get_metrics(run_id, key).map_err(|e| format!("Failed to get metrics: {e}"))?;
 
     if metrics.is_empty() {
         eprintln!("No metrics found for run {run_id}, key '{key}'");
@@ -189,15 +181,9 @@ fn show_metrics(
     Ok(())
 }
 
-fn delete_experiment(
-    store: &SqliteBackend,
-    id: &str,
-    _log_level: LogLevel,
-) -> Result<(), String> {
+fn delete_experiment(store: &SqliteBackend, id: &str, _log_level: LogLevel) -> Result<(), String> {
     // Verify it exists first
-    store
-        .get_experiment(id)
-        .map_err(|e| format!("Failed to find experiment: {e}"))?;
+    store.get_experiment(id).map_err(|e| format!("Failed to find experiment: {e}"))?;
 
     let conn = store.lock_conn().map_err(|e| format!("Lock error: {e}"))?;
 

--- a/src/cli/commands/finetune.rs
+++ b/src/cli/commands/finetune.rs
@@ -25,29 +25,27 @@ pub fn run_finetune(args: FinetuneArgs, level: LogLevel) -> Result<(), String> {
             lr_min_ratio,
             class_weights,
             target_modules,
-        } => {
-            run_plan(
-                data,
-                model_path,
-                model_size,
-                num_classes,
-                output_dir,
-                strategy,
-                budget,
-                scout,
-                max_epochs,
-                lr,
-                lora_rank,
-                batch_size,
-                lora_alpha,
-                warmup,
-                gradient_clip,
-                lr_min_ratio,
-                class_weights,
-                target_modules,
-                level,
-            )
-        }
+        } => run_plan(
+            data,
+            model_path,
+            model_size,
+            num_classes,
+            output_dir,
+            strategy,
+            budget,
+            scout,
+            max_epochs,
+            lr,
+            lora_rank,
+            batch_size,
+            lora_alpha,
+            warmup,
+            gradient_clip,
+            lr_min_ratio,
+            class_weights,
+            target_modules,
+            level,
+        ),
         FinetuneCommand::Apply { plan, model_path, data, output_dir } => {
             run_apply(plan, model_path, data, output_dir, level)
         }
@@ -203,10 +201,7 @@ fn run_apply(
     Ok(())
 }
 
-fn print_plan_summary(
-    plan: &crate::finetune::training_plan::TrainingPlan,
-    level: LogLevel,
-) {
+fn print_plan_summary(plan: &crate::finetune::training_plan::TrainingPlan, level: LogLevel) {
     let (pass, warn, fail) = plan.check_counts();
 
     log(level, LogLevel::Normal, &format!("Plan: {} v{}", plan.task, plan.version));
@@ -258,14 +253,6 @@ fn print_plan_summary(
             plan.resources.estimated_total_minutes,
         ),
     );
-    log(
-        level,
-        LogLevel::Normal,
-        &format!("  Pre-flight: {pass} pass, {warn} warn, {fail} fail"),
-    );
-    log(
-        level,
-        LogLevel::Normal,
-        &format!("  Verdict: {:?}", plan.verdict),
-    );
+    log(level, LogLevel::Normal, &format!("  Pre-flight: {pass} pass, {warn} warn, {fail} fail"));
+    log(level, LogLevel::Normal, &format!("  Verdict: {:?}", plan.verdict));
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -40,11 +40,10 @@ pub use cli::{
     apply_overrides, parse_args, ArchiveProviderArg, ArtifactTypeArg, AuditArgs, AuditType,
     BenchArgs, BundleArgs, CitationFormat, CiteArgs, Cli, Command, CompletionArgs, DepositArgs,
     ExperimentsArgs, ExperimentsCommand, ExportArgs, ExportFormat, FinetuneArgs, FinetuneCommand,
-    InfoArgs, InitArgs,
-    InitTemplate, InspectArgs, InspectMode, LicenseArg, MergeArgs, MergeMethod, MonitorArgs,
-    OutputFormat, PreregisterArgs, PublishArgs, QuantMethod, QuantizeArgs, ResearchArgs,
-    ResearchCommand, ResearchInitArgs, ShellType, TrainArgs, TrainingMethod, ValidateArgs,
-    VerifyArgs,
+    InfoArgs, InitArgs, InitTemplate, InspectArgs, InspectMode, LicenseArg, MergeArgs, MergeMethod,
+    MonitorArgs, OutputFormat, PreregisterArgs, PublishArgs, QuantMethod, QuantizeArgs,
+    ResearchArgs, ResearchCommand, ResearchInitArgs, ShellType, TrainArgs, TrainingMethod,
+    ValidateArgs, VerifyArgs,
 };
 pub use infer::{
     collect_stats_from_samples, infer_schema, infer_schema_from_path, infer_type, ColumnStats,
@@ -52,7 +51,8 @@ pub use infer::{
 };
 pub use schema::{
     is_hf_repo_id, ArchitectureOverrides, CurriculumStage, DataConfig, LoRASpec, MergeSpec,
-    ModelMode, ModelRef, OptimSpec, PublishSpec, QuantSpec, TrainSpec, TrainingMode, TrainingParams,
+    ModelMode, ModelRef, OptimSpec, PublishSpec, QuantSpec, TrainSpec, TrainingMode,
+    TrainingParams,
 };
 pub use train::{load_config, train_from_yaml};
 pub use validate::{validate_config, ValidationError};

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -134,11 +134,7 @@ pub struct ArchitectureOverrides {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub num_attention_heads: Option<usize>,
     /// Number of key-value heads (for grouped-query attention)
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        alias = "num_key_value_heads"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "num_key_value_heads")]
     pub num_kv_heads: Option<usize>,
     /// FFN intermediate dimension
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/config/train/batches/streaming.rs
+++ b/src/config/train/batches/streaming.rs
@@ -31,11 +31,7 @@ pub struct ShardConfig {
 impl ShardConfig {
     /// Create a single-worker (no sharding) config.
     pub fn single() -> Self {
-        Self {
-            rank: 0,
-            world_size: 1,
-            seed: 42,
-        }
+        Self { rank: 0, world_size: 1, seed: 42 }
     }
 }
 
@@ -300,7 +296,8 @@ mod tests {
     fn test_streaming_loader_basic() {
         let (dir, _) = create_temp_dir_with_files(4);
         let config = ShardConfig { rank: 0, world_size: 2, seed: 42 };
-        let loader = StreamingParquetLoader::new(dir.path(), config, 4, 2048).expect("create loader");
+        let loader =
+            StreamingParquetLoader::new(dir.path(), config, 4, 2048).expect("create loader");
         assert_eq!(loader.num_files(), 2);
         assert_eq!(loader.total_files(), 4);
     }

--- a/src/config/train/loader.rs
+++ b/src/config/train/loader.rs
@@ -132,10 +132,8 @@ fn build_train_config(
             "wgpu" => DistributedBackend::Wgpu,
             _ => DistributedBackend::Auto,
         };
-        let addr: std::net::SocketAddr = dist
-            .coordinator_addr
-            .parse()
-            .unwrap_or_else(|_| "0.0.0.0:9000".parse().unwrap());
+        let addr: std::net::SocketAddr =
+            dist.coordinator_addr.parse().unwrap_or_else(|_| "0.0.0.0:9000".parse().unwrap());
 
         config = config.with_distributed(DistributedTrainConfig {
             world_size: dist.world_size,
@@ -192,18 +190,13 @@ fn train_transformer_from_spec(spec: &TrainSpec) -> Result<()> {
     if train_config.use_cuda {
         let cuda_config = train_config.clone();
         let cuda_result = match transformer {
-            Some(loaded_model) => {
-                CudaTransformerTrainer::with_model(loaded_model, cuda_config)
-            }
+            Some(loaded_model) => CudaTransformerTrainer::with_model(loaded_model, cuda_config),
             None => CudaTransformerTrainer::new(cuda_config),
         };
 
         match cuda_result {
             Ok(mut cuda_trainer) => {
-                println!(
-                    "✓ CudaTransformerTrainer initialized (GPU: {})",
-                    cuda_trainer.gpu_name()
-                );
+                println!("✓ CudaTransformerTrainer initialized (GPU: {})", cuda_trainer.gpu_name());
                 // #133: Dispatch to distributed training loop if distributed config present
                 if train_config.distributed.is_some() {
                     return train_loop_cuda_distributed(cuda_trainer, &batches, spec);
@@ -262,9 +255,19 @@ fn train_loop_cpu(
     let mut tracker = PretrainTracker::open(spec, "CPU");
 
     write_training_snapshot(
-        &state, start_ms, 0, total_epochs, 0, num_batches,
-        0.0, &[], 0.0, 0.0,
-        TrainingStatus::Initializing, spec, "CPU",
+        &state,
+        start_ms,
+        0,
+        total_epochs,
+        0,
+        num_batches,
+        0.0,
+        &[],
+        0.0,
+        0.0,
+        TrainingStatus::Initializing,
+        spec,
+        "CPU",
     );
 
     if let Some(max_steps) = spec.training.max_steps {
@@ -275,49 +278,73 @@ fn train_loop_cpu(
 
     for epoch in 0..spec.training.epochs {
         let epoch_start = std::time::Instant::now();
-        let avg_loss = trainer.train_epoch_with_callback(batches, |batch_idx, batch_loss, trainer| {
-            loss_history.push(batch_loss);
-            if loss_history.len() > 100 {
-                loss_history.remove(0);
-            }
+        let avg_loss =
+            trainer.train_epoch_with_callback(batches, |batch_idx, batch_loss, trainer| {
+                loss_history.push(batch_loss);
+                if loss_history.len() > 100 {
+                    loss_history.remove(0);
+                }
 
-            if (batch_idx + 1) % log_interval == 0 || batch_idx == 0 {
-                let elapsed = epoch_start.elapsed().as_secs_f64();
-                let batches_done = batch_idx + 1;
-                let seq_len = spec.data.seq_len.unwrap_or(128);
-                let tokens_done = batches_done * spec.data.batch_size * seq_len;
-                let batch_per_sec = batches_done as f64 / elapsed.max(0.001);
-                let remaining = (num_batches - batches_done) as f64 / batch_per_sec.max(0.001);
-                let tok_per_sec = tokens_done as f64 / elapsed.max(0.001);
-                println!(
-                    "  [{}/{} batches] step={} loss={:.4} lr={:.2e} tok/s={:.0} eta={:.0}s",
-                    batches_done, num_batches,
-                    trainer.step(), batch_loss, trainer.current_lr(),
-                    tok_per_sec, remaining,
-                );
+                if (batch_idx + 1) % log_interval == 0 || batch_idx == 0 {
+                    let elapsed = epoch_start.elapsed().as_secs_f64();
+                    let batches_done = batch_idx + 1;
+                    let seq_len = spec.data.seq_len.unwrap_or(128);
+                    let tokens_done = batches_done * spec.data.batch_size * seq_len;
+                    let batch_per_sec = batches_done as f64 / elapsed.max(0.001);
+                    let remaining = (num_batches - batches_done) as f64 / batch_per_sec.max(0.001);
+                    let tok_per_sec = tokens_done as f64 / elapsed.max(0.001);
+                    println!(
+                        "  [{}/{} batches] step={} loss={:.4} lr={:.2e} tok/s={:.0} eta={:.0}s",
+                        batches_done,
+                        num_batches,
+                        trainer.step(),
+                        batch_loss,
+                        trainer.current_lr(),
+                        tok_per_sec,
+                        remaining,
+                    );
 
-                // ALB-045: Write snapshot for `apr monitor`
-                write_training_snapshot(
-                    &state, start_ms, epoch + 1, total_epochs,
-                    trainer.step(), num_batches,
-                    batch_loss, &loss_history,
-                    trainer.current_lr(), tok_per_sec as f32,
-                    TrainingStatus::Running, spec, "CPU",
-                );
+                    // ALB-045: Write snapshot for `apr monitor`
+                    write_training_snapshot(
+                        &state,
+                        start_ms,
+                        epoch + 1,
+                        total_epochs,
+                        trainer.step(),
+                        num_batches,
+                        batch_loss,
+                        &loss_history,
+                        trainer.current_lr(),
+                        tok_per_sec as f32,
+                        TrainingStatus::Running,
+                        spec,
+                        "CPU",
+                    );
 
-                // ALB-055/056: Log step metrics to SQLite
-                tracker.log_step(trainer.step() as u64, batch_loss, trainer.current_lr(), tok_per_sec as f32);
-            }
-        });
+                    // ALB-055/056: Log step metrics to SQLite
+                    tracker.log_step(
+                        trainer.step() as u64,
+                        batch_loss,
+                        trainer.current_lr(),
+                        tok_per_sec as f32,
+                    );
+                }
+            });
         let ppl = crate::train::perplexity(avg_loss);
         println!(
             "Epoch {}/{}: loss={:.6}, perplexity={:.2}, time={:.1}s",
-            epoch + 1, spec.training.epochs, avg_loss, ppl,
+            epoch + 1,
+            spec.training.epochs,
+            avg_loss,
+            ppl,
             epoch_start.elapsed().as_secs_f64(),
         );
 
         if trainer.reached_max_steps() {
-            println!("Reached max_steps={}, stopping training.", spec.training.max_steps.unwrap_or(0));
+            println!(
+                "Reached max_steps={}, stopping training.",
+                spec.training.max_steps.unwrap_or(0)
+            );
             break;
         }
     }
@@ -329,11 +356,19 @@ fn train_loop_cpu(
     // ALB-045: Write final "Completed" snapshot
     let final_loss = trainer.metrics.losses.last().copied().unwrap_or(0.0);
     write_training_snapshot(
-        &state, start_ms, total_epochs, total_epochs,
-        trainer.step(), num_batches,
-        final_loss, &loss_history,
-        trainer.current_lr(), 0.0,
-        TrainingStatus::Completed, spec, "CPU",
+        &state,
+        start_ms,
+        total_epochs,
+        total_epochs,
+        trainer.step(),
+        num_batches,
+        final_loss,
+        &loss_history,
+        trainer.current_lr(),
+        0.0,
+        TrainingStatus::Completed,
+        spec,
+        "CPU",
     );
 
     // ALB-055/056: Mark run as completed in SQLite
@@ -344,10 +379,7 @@ fn train_loop_cpu(
 
 /// Get current Unix timestamp in milliseconds
 fn now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis() as u64).unwrap_or(0)
 }
 
 /// Query live GPU telemetry via nvidia-smi CLI (ALB-046)
@@ -420,10 +452,12 @@ fn write_training_snapshot(
         gradient_norm: 0.0, // not tracked per-batch in current trainer
         tokens_per_second,
         start_timestamp_ms: start_ms,
-        gpu: query_gpu_telemetry(gpu_name).or_else(|| Some(crate::monitor::tui::state::GpuTelemetry {
-            device_name: gpu_name.to_string(),
-            ..Default::default()
-        })),
+        gpu: query_gpu_telemetry(gpu_name).or_else(|| {
+            Some(crate::monitor::tui::state::GpuTelemetry {
+                device_name: gpu_name.to_string(),
+                ..Default::default()
+            })
+        }),
         sample: None,
         status,
         experiment_id: spec.training.output_dir.display().to_string(),
@@ -462,10 +496,8 @@ struct PretrainTracker {
 impl PretrainTracker {
     /// Open both local and global SQLite stores, create experiment + run.
     fn open(spec: &TrainSpec, device: &str) -> Self {
-        let exp_name = spec.training.output_dir
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("pretrain");
+        let exp_name =
+            spec.training.output_dir.file_name().and_then(|n| n.to_str()).unwrap_or("pretrain");
 
         let config_json = serde_json::json!({
             "task": "pretrain",
@@ -484,12 +516,10 @@ impl PretrainTracker {
         let local = SqliteBackend::open_project(&spec.training.output_dir).ok();
 
         // Global store: ~/.entrenar/experiments.db
-        let global = dirs::home_dir()
-            .map(|h| h.join(".entrenar"))
-            .and_then(|p| {
-                fs::create_dir_all(&p).ok()?;
-                SqliteBackend::open(p.join("experiments.db").to_string_lossy().as_ref()).ok()
-            });
+        let global = dirs::home_dir().map(|h| h.join(".entrenar")).and_then(|p| {
+            fs::create_dir_all(&p).ok()?;
+            SqliteBackend::open(p.join("experiments.db").to_string_lossy().as_ref()).ok()
+        });
 
         let mut tracker = Self { local, global, run_id: None, global_run_id: None };
 
@@ -561,13 +591,26 @@ impl PretrainTracker {
 /// Log hyperparameters for a pretrain run (ALB-055/056)
 fn log_run_params(store: &SqliteBackend, run_id: &str, spec: &TrainSpec, device: &str) {
     let _ = store.log_param(run_id, "task", ParameterValue::String("pretrain".into()));
-    let _ = store.log_param(run_id, "model", ParameterValue::String(spec.model.path.display().to_string()));
-    let _ = store.log_param(run_id, "optimizer", ParameterValue::String(spec.optimizer.name.clone()));
-    let _ = store.log_param(run_id, "learning_rate", ParameterValue::Float(f64::from(spec.optimizer.lr)));
+    let _ = store.log_param(
+        run_id,
+        "model",
+        ParameterValue::String(spec.model.path.display().to_string()),
+    );
+    let _ =
+        store.log_param(run_id, "optimizer", ParameterValue::String(spec.optimizer.name.clone()));
+    let _ = store.log_param(
+        run_id,
+        "learning_rate",
+        ParameterValue::Float(f64::from(spec.optimizer.lr)),
+    );
     let _ = store.log_param(run_id, "epochs", ParameterValue::Int(spec.training.epochs as i64));
     let _ = store.log_param(run_id, "batch_size", ParameterValue::Int(spec.data.batch_size as i64));
     let _ = store.log_param(run_id, "device", ParameterValue::String(device.to_string()));
-    let _ = store.log_param(run_id, "output_dir", ParameterValue::String(spec.training.output_dir.display().to_string()));
+    let _ = store.log_param(
+        run_id,
+        "output_dir",
+        ParameterValue::String(spec.training.output_dir.display().to_string()),
+    );
     if let Some(seq_len) = spec.data.seq_len {
         let _ = store.log_param(run_id, "seq_len", ParameterValue::Int(seq_len as i64));
     }
@@ -620,20 +663,23 @@ fn train_loop_cuda(
     // R-014: Open JSONL experiment log
     let jsonl_path = spec.training.output_dir.join("training_log.jsonl");
     std::fs::create_dir_all(&spec.training.output_dir).ok();
-    let mut jsonl_file = std::fs::OpenOptions::new()
-        .create(true).append(true).open(&jsonl_path).ok();
+    let mut jsonl_file =
+        std::fs::OpenOptions::new().create(true).append(true).open(&jsonl_path).ok();
     // Write config header
-    write_jsonl_event_json(&mut jsonl_file, &serde_json::json!({
-        "type": "config",
-        "num_params": num_params,
-        "batch_size": spec.data.batch_size,
-        "seq_len": seq_len,
-        "max_steps": spec.training.max_steps,
-        "epochs": spec.training.epochs,
-        "lr": spec.optimizer.lr,
-        "gpu": &gpu_name,
-        "timestamp": now_ms(),
-    }));
+    write_jsonl_event_json(
+        &mut jsonl_file,
+        &serde_json::json!({
+            "type": "config",
+            "num_params": num_params,
+            "batch_size": spec.data.batch_size,
+            "seq_len": seq_len,
+            "max_steps": spec.training.max_steps,
+            "epochs": spec.training.epochs,
+            "lr": spec.optimizer.lr,
+            "gpu": &gpu_name,
+            "timestamp": now_ms(),
+        }),
+    );
 
     // R-008: Graceful shutdown signal handler
     let shutdown_flag = Arc::new(AtomicBool::new(false));
@@ -647,9 +693,19 @@ fn train_loop_cuda(
 
     // Write initial "Initializing" snapshot
     write_training_snapshot(
-        &state, start_ms, 0, total_epochs, 0, num_batches,
-        0.0, &[], 0.0, 0.0,
-        TrainingStatus::Initializing, spec, &gpu_name,
+        &state,
+        start_ms,
+        0,
+        total_epochs,
+        0,
+        num_batches,
+        0.0,
+        &[],
+        0.0,
+        0.0,
+        TrainingStatus::Initializing,
+        spec,
+        &gpu_name,
     );
 
     if let Some(max_steps) = spec.training.max_steps {
@@ -660,7 +716,10 @@ fn train_loop_cuda(
     let mut loss_history: Vec<f32> = Vec::new();
     let mut last_save_step: usize = 0;
 
-    let model_name = spec.model.path.file_name()
+    let model_name = spec
+        .model
+        .path
+        .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("entrenar-model")
         .to_string();
@@ -716,10 +775,20 @@ fn train_loop_cuda(
             // R-008: Check graceful shutdown flag
             if shutdown_flag.load(Ordering::SeqCst) {
                 handle_graceful_shutdown(
-                    trainer, spec, &state, &mut tracker, start_ms,
-                    epoch, iter_idx, total_epochs, num_batches,
-                    &loss_history, &model_name, &gpu_name,
-                    seed, loss_ema,
+                    trainer,
+                    spec,
+                    &state,
+                    &mut tracker,
+                    start_ms,
+                    epoch,
+                    iter_idx,
+                    total_epochs,
+                    num_batches,
+                    &loss_history,
+                    &model_name,
+                    &gpu_name,
+                    seed,
+                    loss_ema,
                 );
                 return Ok(());
             }
@@ -731,7 +800,10 @@ fn train_loop_cuda(
 
             // R-023: Check curriculum stage transition
             curriculum_stage = check_curriculum_transition(
-                curriculum, curriculum_stage, trainer.step(), &mut jsonl_file,
+                curriculum,
+                curriculum_stage,
+                trainer.step(),
+                &mut jsonl_file,
             );
 
             let batch = &batches[batch_idx];
@@ -743,7 +815,11 @@ fn train_loop_cuda(
             // R-018: NaN/Inf detection — skip step if loss is non-finite
             if !batch_loss.is_finite() {
                 nan_skips += 1;
-                println!("  [WARN] NaN/Inf loss at step {} (skip #{}) — skipping", trainer.step(), nan_skips);
+                println!(
+                    "  [WARN] NaN/Inf loss at step {} (skip #{}) — skipping",
+                    trainer.step(),
+                    nan_skips
+                );
                 continue;
             }
             total_loss += batch_loss;
@@ -751,20 +827,33 @@ fn train_loop_cuda(
 
             // R-016b: Loss spike detection + rollback
             detect_loss_spike(
-                batch_loss, trainer.step(), &mut loss_ema, loss_ema_alpha,
-                loss_spike_threshold, &mut rollback_count, max_rollbacks, &mut jsonl_file,
+                batch_loss,
+                trainer.step(),
+                &mut loss_ema,
+                loss_ema_alpha,
+                loss_spike_threshold,
+                &mut rollback_count,
+                max_rollbacks,
+                &mut jsonl_file,
             );
 
             // R-017: ZClip — update EMA and detect gradient spikes
             zclip_update(
-                trainer.last_grad_norm() as f64, trainer.step(),
-                &mut gnorm_ema, &mut gnorm_ema_sq, zclip_alpha, zclip_threshold,
+                trainer.last_grad_norm() as f64,
+                trainer.step(),
+                &mut gnorm_ema,
+                &mut gnorm_ema_sq,
+                zclip_alpha,
+                zclip_threshold,
             );
 
             // R-029: Track grad norm for noise scale estimation
             update_noise_scale(
-                trainer.last_grad_norm() as f64, trainer.step(),
-                &mut gnorm_window, noise_scale_interval, &mut jsonl_file,
+                trainer.last_grad_norm() as f64,
+                trainer.step(),
+                &mut gnorm_window,
+                noise_scale_interval,
+                &mut jsonl_file,
             );
 
             // R-003: Write heartbeat for crash detection
@@ -776,11 +865,25 @@ fn train_loop_cuda(
             // Logging at log_interval boundaries
             if should_log(iter_idx, log_interval) {
                 log_step_metrics(
-                    trainer, &state, &mut tracker, &mut jsonl_file,
-                    &epoch_start, &start_time, &step_elapsed,
-                    epoch, total_epochs, iter_idx, num_batches,
-                    tokens_per_batch, num_params, gpu_peak_tflops,
-                    start_ms, batch_loss, &loss_history, spec, &gpu_name,
+                    trainer,
+                    &state,
+                    &mut tracker,
+                    &mut jsonl_file,
+                    &epoch_start,
+                    &start_time,
+                    &step_elapsed,
+                    epoch,
+                    total_epochs,
+                    iter_idx,
+                    num_batches,
+                    tokens_per_batch,
+                    num_params,
+                    gpu_peak_tflops,
+                    start_ms,
+                    batch_loss,
+                    &loss_history,
+                    spec,
+                    &gpu_name,
                 );
             }
 
@@ -788,9 +891,17 @@ fn train_loop_cuda(
             let current_step = trainer.step();
             if should_save_checkpoint(current_step, last_save_step, save_interval) {
                 save_and_validate_checkpoint(
-                    trainer, spec, &val_batches, &model_name,
-                    current_step, epoch, iter_idx, max_checkpoints,
-                    &mut jsonl_file, seed, loss_ema,
+                    trainer,
+                    spec,
+                    &val_batches,
+                    &model_name,
+                    current_step,
+                    epoch,
+                    iter_idx,
+                    max_checkpoints,
+                    &mut jsonl_file,
+                    seed,
+                    loss_ema,
                 );
                 last_save_step = current_step;
             }
@@ -800,7 +911,10 @@ fn train_loop_cuda(
         let ppl = crate::train::perplexity(avg_loss);
         println!(
             "Epoch {}/{}: loss={:.6}, perplexity={:.2}, time={:.1}s",
-            epoch + 1, spec.training.epochs, avg_loss, ppl,
+            epoch + 1,
+            spec.training.epochs,
+            avg_loss,
+            ppl,
             epoch_start.elapsed().as_secs_f64(),
         );
 
@@ -815,24 +929,35 @@ fn train_loop_cuda(
     // ALB-045: Write final "Completed" snapshot
     let final_loss = trainer.metrics.losses.last().copied().unwrap_or(0.0);
     write_training_snapshot(
-        &state, start_ms, total_epochs, total_epochs,
-        trainer.step(), num_batches,
-        final_loss, &loss_history,
-        trainer.current_lr(), 0.0,
-        TrainingStatus::Completed, spec, &gpu_name,
+        &state,
+        start_ms,
+        total_epochs,
+        total_epochs,
+        trainer.step(),
+        num_batches,
+        final_loss,
+        &loss_history,
+        trainer.current_lr(),
+        0.0,
+        TrainingStatus::Completed,
+        spec,
+        &gpu_name,
     );
 
     // ALB-055/056: Mark run as completed in SQLite
     tracker.complete();
 
     // R-014: Write completion entry
-    write_jsonl_event_json(&mut jsonl_file, &serde_json::json!({
-        "type": "complete",
-        "step": trainer.step(),
-        "final_loss": final_loss,
-        "total_time_s": total_time.as_secs_f64(),
-        "timestamp": now_ms(),
-    }));
+    write_jsonl_event_json(
+        &mut jsonl_file,
+        &serde_json::json!({
+            "type": "complete",
+            "step": trainer.step(),
+            "final_loss": final_loss,
+            "total_time_s": total_time.as_secs_f64(),
+            "timestamp": now_ms(),
+        }),
+    );
 
     save_trained_model_cuda(trainer, spec)
 }
@@ -852,8 +977,8 @@ fn spawn_coordinator_thread(
     num_blocks: usize,
     total_steps: usize,
 ) -> Result<std::thread::JoinHandle<()>> {
-    use crate::finetune::GradientServer;
     use crate::finetune::distributed::DistributedConfig;
+    use crate::finetune::GradientServer;
 
     let server_config = DistributedConfig::coordinator(coord_addr, world_size);
     let mut server = GradientServer::bind(server_config)
@@ -866,20 +991,13 @@ fn spawn_coordinator_thread(
 
         for _step in 0..total_steps {
             for block_idx in (0..num_blocks).rev() {
-                let result = server
-                    .collect_and_reduce_block(_step as u64, block_idx as u32)
-                    .unwrap();
-                server
-                    .broadcast_averaged_block(_step as u64, &result)
-                    .unwrap();
+                let result =
+                    server.collect_and_reduce_block(_step as u64, block_idx as u32).unwrap();
+                server.broadcast_averaged_block(_step as u64, &result).unwrap();
             }
             for component in [0u8, 1, 2] {
-                let result = server
-                    .collect_and_reduce_non_block(_step as u64, component)
-                    .unwrap();
-                server
-                    .broadcast_averaged_non_block(_step as u64, &result)
-                    .unwrap();
+                let result = server.collect_and_reduce_non_block(_step as u64, component).unwrap();
+                server.broadcast_averaged_non_block(_step as u64, &result).unwrap();
             }
         }
         eprintln!("[coordinator] Training complete ({total_steps} steps)");
@@ -892,9 +1010,9 @@ fn train_loop_cuda_distributed(
     batches: &[LMBatch],
     spec: &TrainSpec,
 ) -> Result<()> {
-    use crate::finetune::WorkerClient;
     use crate::finetune::distributed::DistributedConfig;
-    use crate::train::{DistributedCudaTrainer, DistributedComm, shard_batches};
+    use crate::finetune::WorkerClient;
+    use crate::train::{shard_batches, DistributedComm, DistributedCudaTrainer};
 
     let dist_config = cuda_trainer
         .config()
@@ -912,10 +1030,7 @@ fn train_loop_cuda_distributed(
 
     cuda_trainer.ensure_grad_accum();
 
-    let num_blocks = cuda_trainer
-        .grad_accum_ref()
-        .map(|a| a.num_blocks())
-        .unwrap_or(0);
+    let num_blocks = cuda_trainer.grad_accum_ref().map(|a| a.num_blocks()).unwrap_or(0);
 
     // Step 1: If rank 0, spawn GradientServer in background thread
     let server_handle = if rank == 0 {
@@ -1086,9 +1201,12 @@ fn reached_max_steps(max_steps: Option<usize>, current_step: usize) -> bool {
 
 /// R-017: ZClip gradient spike detection — update EMA and log spikes.
 fn zclip_update(
-    gnorm: f64, step: usize,
-    ema: &mut f64, ema_sq: &mut f64,
-    alpha: f64, threshold: f64,
+    gnorm: f64,
+    step: usize,
+    ema: &mut f64,
+    ema_sq: &mut f64,
+    alpha: f64,
+    threshold: f64,
 ) {
     *ema = alpha * gnorm + (1.0 - alpha) * *ema;
     *ema_sq = alpha * gnorm * gnorm + (1.0 - alpha) * *ema_sq;
@@ -1096,8 +1214,10 @@ fn zclip_update(
     if std > 1e-8 {
         let z_score = (gnorm - *ema) / std;
         if z_score > threshold {
-            println!("  [ZClip] gradient spike at step {}: z={:.1} gnorm={:.2e} ema={:.2e}",
-                step, z_score, gnorm, *ema);
+            println!(
+                "  [ZClip] gradient spike at step {}: z={:.1} gnorm={:.2e} ema={:.2e}",
+                step, z_score, gnorm, *ema
+            );
         }
     }
 }
@@ -1122,8 +1242,10 @@ fn push_capped_f64(window: &mut Vec<f64>, value: f64, max_len: usize) {
 /// B_noise = Var(||g||) / Mean(||g||)² — proxy for critical batch size.
 #[allow(clippy::incompatible_msrv)]
 fn update_noise_scale(
-    grad_norm: f64, step: usize,
-    window: &mut Vec<f64>, interval: usize,
+    grad_norm: f64,
+    step: usize,
+    window: &mut Vec<f64>,
+    interval: usize,
     jsonl_file: &mut Option<std::fs::File>,
 ) {
     push_capped_f64(window, grad_norm, 100);
@@ -1138,30 +1260,39 @@ fn update_noise_scale(
     let variance = window.iter().map(|&g| (g - mean).powi(2)).sum::<f64>() / (n - 1.0);
     let b_noise = variance / (mean * mean);
     println!("  [noise-scale] step={} B_noise={:.4} (window={})", step, b_noise, window.len());
-    write_jsonl_event_json(jsonl_file, &serde_json::json!({
-        "type": "noise_scale",
-        "step": step,
-        "b_noise": b_noise,
-        "gnorm_mean": mean,
-        "gnorm_var": variance,
-        "window_size": window.len(),
-        "timestamp": now_ms(),
-    }));
+    write_jsonl_event_json(
+        jsonl_file,
+        &serde_json::json!({
+            "type": "noise_scale",
+            "step": step,
+            "b_noise": b_noise,
+            "gnorm_mean": mean,
+            "gnorm_var": variance,
+            "window_size": window.len(),
+            "timestamp": now_ms(),
+        }),
+    );
 }
 
 /// R-016b: Detect loss spikes and log rollback events.
 #[allow(clippy::too_many_arguments)]
 fn detect_loss_spike(
-    loss: f32, step: usize,
-    ema: &mut f64, alpha: f64, threshold: f64,
-    rollback_count: &mut usize, max_rollbacks: usize,
+    loss: f32,
+    step: usize,
+    ema: &mut f64,
+    alpha: f64,
+    threshold: f64,
+    rollback_count: &mut usize,
+    max_rollbacks: usize,
     jsonl_file: &mut Option<std::fs::File>,
 ) {
     let bl = f64::from(loss);
     if *ema > 0.0 && bl > threshold * *ema && *rollback_count < max_rollbacks {
         *rollback_count += 1;
-        println!("  [ROLLBACK] loss spike at step {}: {:.4} > {:.1}×EMA({:.4}), rollback #{}/{}",
-            step, loss, threshold, *ema, *rollback_count, max_rollbacks);
+        println!(
+            "  [ROLLBACK] loss spike at step {}: {:.4} > {:.1}×EMA({:.4}), rollback #{}/{}",
+            step, loss, threshold, *ema, *rollback_count, max_rollbacks
+        );
         write_jsonl_event(jsonl_file, "rollback", step, loss, *ema as f32);
     }
     *ema = alpha * bl + (1.0 - alpha) * *ema;
@@ -1170,7 +1301,10 @@ fn detect_loss_spike(
 /// Write a generic event entry to the JSONL experiment log.
 fn write_jsonl_event(
     jsonl_file: &mut Option<std::fs::File>,
-    event_type: &str, step: usize, loss: f32, loss_ema: f32,
+    event_type: &str,
+    step: usize,
+    loss: f32,
+    loss_ema: f32,
 ) {
     use std::io::Write;
     if let Some(ref mut f) = jsonl_file {
@@ -1186,10 +1320,7 @@ fn write_jsonl_event(
 }
 
 /// Write an arbitrary JSON event to the JSONL log (generic version).
-fn write_jsonl_event_json(
-    jsonl_file: &mut Option<std::fs::File>,
-    entry: &serde_json::Value,
-) {
+fn write_jsonl_event_json(jsonl_file: &mut Option<std::fs::File>, entry: &serde_json::Value) {
     use std::io::Write;
     if let Some(ref mut f) = jsonl_file {
         let _ = writeln!(f, "{entry}");
@@ -1258,8 +1389,14 @@ fn load_val_batches(spec: &TrainSpec) -> Vec<LMBatch> {
     if val_path.is_dir() {
         if let Some(tok) = tokenizer_ref {
             let column = spec.data.input_column.as_deref().unwrap_or("text");
-            if let Ok(batches) = load_lm_batches_from_parquet(val_path, tok, batch_size, seq_len, column) {
-                println!("  ✓ {} validation batches loaded from {}", batches.len(), val_path.display());
+            if let Ok(batches) =
+                load_lm_batches_from_parquet(val_path, tok, batch_size, seq_len, column)
+            {
+                println!(
+                    "  ✓ {} validation batches loaded from {}",
+                    batches.len(),
+                    val_path.display()
+                );
                 return batches;
             }
         }
@@ -1292,7 +1429,10 @@ fn run_validation_eval(
     }
     let val_loss = total_loss / count as f32;
     let val_ppl = crate::train::perplexity(val_loss);
-    println!("  [eval] step={} val_loss={:.4} val_ppl={:.2} ({} batches)", step, val_loss, val_ppl, count);
+    println!(
+        "  [eval] step={} val_loss={:.4} val_ppl={:.2} ({} batches)",
+        step, val_loss, val_ppl, count
+    );
 
     // Log to JSONL
     use std::io::Write;
@@ -1375,9 +1515,7 @@ fn shuffled_batch_order(num_batches: usize, shuffle: bool, seed: u64, epoch: usi
         .wrapping_mul(6364136223846793005)
         .wrapping_add(1442695040888963407);
     for i in (1..indices.len()).rev() {
-        rng_state = rng_state
-            .wrapping_mul(6364136223846793005)
-            .wrapping_add(1442695040888963407);
+        rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
         let j = (rng_state >> 33) as usize % (i + 1);
         indices.swap(i, j);
     }
@@ -1409,15 +1547,30 @@ fn handle_graceful_shutdown(
         println!("  [WARN] Emergency save failed: {}", e);
     } else {
         println!("  [checkpoint] emergency save to {}", ckpt_path.display());
-        save_training_state(&spec.training.output_dir, trainer.step(), epoch, iter_idx, seed, loss_ema);
+        save_training_state(
+            &spec.training.output_dir,
+            trainer.step(),
+            epoch,
+            iter_idx,
+            seed,
+            loss_ema,
+        );
     }
     let final_loss = trainer.metrics.losses.last().copied().unwrap_or(0.0);
     write_training_snapshot(
-        state, start_ms, epoch + 1, total_epochs,
-        trainer.step(), num_batches,
-        final_loss, loss_history,
-        trainer.current_lr(), 0.0,
-        TrainingStatus::Completed, spec, gpu_name,
+        state,
+        start_ms,
+        epoch + 1,
+        total_epochs,
+        trainer.step(),
+        num_batches,
+        final_loss,
+        loss_history,
+        trainer.current_lr(),
+        0.0,
+        TrainingStatus::Completed,
+        spec,
+        gpu_name,
     );
     tracker.complete();
     println!("[SIGINT] Shutdown complete.");
@@ -1443,15 +1596,22 @@ fn check_curriculum_transition(
 ) -> usize {
     let Some(stages) = curriculum else { return current_stage };
     let Some(next) = advance_curriculum(stages, current_stage, step) else { return current_stage };
-    println!("  [Curriculum] → Stage {} at step {} (data: {})",
-        next, step, stages[next].data.display());
-    write_jsonl_event_json(jsonl_file, &serde_json::json!({
-        "type": "curriculum_transition",
-        "stage": next,
-        "step": step,
-        "data": stages[next].data.to_string_lossy(),
-        "timestamp": now_ms(),
-    }));
+    println!(
+        "  [Curriculum] → Stage {} at step {} (data: {})",
+        next,
+        step,
+        stages[next].data.display()
+    );
+    write_jsonl_event_json(
+        jsonl_file,
+        &serde_json::json!({
+            "type": "curriculum_transition",
+            "stage": next,
+            "step": step,
+            "data": stages[next].data.to_string_lossy(),
+            "timestamp": now_ms(),
+        }),
+    );
     next
 }
 
@@ -1478,9 +1638,15 @@ fn advance_curriculum(
 #[allow(clippy::too_many_arguments)]
 fn write_jsonl_step(
     jsonl_file: &mut Option<std::fs::File>,
-    step: usize, loss: f32, lr: f32, tok_s: f64,
-    mfu: f64, grad_norm: f32, embed_grad_norm: f32,
-    epoch: usize, elapsed_s: f64,
+    step: usize,
+    loss: f32,
+    lr: f32,
+    tok_s: f64,
+    mfu: f64,
+    grad_norm: f32,
+    embed_grad_norm: f32,
+    epoch: usize,
+    elapsed_s: f64,
 ) {
     use std::io::Write;
     if let Some(ref mut f) = jsonl_file {
@@ -1508,11 +1674,7 @@ fn checkpoint_path(output_dir: &Path, step: usize) -> PathBuf {
 
 /// Parse step number from a checkpoint filename like "model-step-123.safetensors".
 fn parse_checkpoint_step(filename: &str) -> Option<usize> {
-    filename
-        .strip_prefix("model-step-")?
-        .strip_suffix(".safetensors")?
-        .parse()
-        .ok()
+    filename.strip_prefix("model-step-")?.strip_suffix(".safetensors")?.parse().ok()
 }
 
 /// Log step metrics: console output, IPC snapshot, SQLite, JSONL.
@@ -1526,12 +1688,18 @@ fn log_step_metrics(
     epoch_start: &std::time::Instant,
     start_time: &std::time::Instant,
     step_elapsed: &std::time::Duration,
-    epoch: usize, total_epochs: usize,
-    iter_idx: usize, num_batches: usize,
-    tokens_per_batch: usize, num_params: usize,
-    gpu_peak_tflops: f64, start_ms: u64,
-    batch_loss: f32, loss_history: &[f32],
-    spec: &TrainSpec, gpu_name: &str,
+    epoch: usize,
+    total_epochs: usize,
+    iter_idx: usize,
+    num_batches: usize,
+    tokens_per_batch: usize,
+    num_params: usize,
+    gpu_peak_tflops: f64,
+    start_ms: u64,
+    batch_loss: f32,
+    loss_history: &[f32],
+    spec: &TrainSpec,
+    gpu_name: &str,
 ) {
     let elapsed = epoch_start.elapsed().as_secs_f64();
     let batches_done = iter_idx + 1;
@@ -1561,20 +1729,37 @@ fn log_step_metrics(
 
     // ALB-045: Write snapshot for `apr monitor`
     write_training_snapshot(
-        state, start_ms, epoch + 1, total_epochs,
-        trainer.step(), num_batches,
-        batch_loss, loss_history,
-        trainer.current_lr(), tok_per_sec as f32,
-        TrainingStatus::Running, spec, gpu_name,
+        state,
+        start_ms,
+        epoch + 1,
+        total_epochs,
+        trainer.step(),
+        num_batches,
+        batch_loss,
+        loss_history,
+        trainer.current_lr(),
+        tok_per_sec as f32,
+        TrainingStatus::Running,
+        spec,
+        gpu_name,
     );
 
     // ALB-055/056: Log step metrics to SQLite
     tracker.log_step(trainer.step() as u64, batch_loss, trainer.current_lr(), tok_per_sec as f32);
 
     // R-014: Write JSONL log entry
-    write_jsonl_step(jsonl_file, trainer.step(), batch_loss,
-        trainer.current_lr(), tok_per_sec, mfu, grad_norm, embed_grad_norm,
-        epoch, start_time.elapsed().as_secs_f64());
+    write_jsonl_step(
+        jsonl_file,
+        trainer.step(),
+        batch_loss,
+        trainer.current_lr(),
+        tok_per_sec,
+        mfu,
+        grad_norm,
+        embed_grad_norm,
+        epoch,
+        start_time.elapsed().as_secs_f64(),
+    );
 }
 
 /// R-009: Prune old checkpoints, keeping the most recent `max_keep`.
@@ -1607,8 +1792,12 @@ fn prune_checkpoints(output_dir: &Path, max_keep: usize) {
 
 /// R-006/R-007: Save training state metadata alongside checkpoint.
 fn save_training_state(
-    output_dir: &Path, step: usize, epoch: usize, batch_idx: usize,
-    seed: u64, loss_ema: f64,
+    output_dir: &Path,
+    step: usize,
+    epoch: usize,
+    batch_idx: usize,
+    seed: u64,
+    loss_ema: f64,
 ) {
     let state = serde_json::json!({
         "step": step,
@@ -1624,7 +1813,6 @@ fn save_training_state(
     }
 }
 
-
 /// Save trained model from CPU trainer
 fn save_trained_model_cpu(trainer: &TransformerTrainer, spec: &TrainSpec) -> Result<()> {
     println!();
@@ -1637,9 +1825,8 @@ fn save_trained_model_cpu(trainer: &TransformerTrainer, spec: &TrainSpec) -> Res
     std::fs::create_dir_all(&spec.training.output_dir).ok();
 
     let weights_path = spec.training.output_dir.join("model.safetensors");
-    let model_name = spec.model.path.file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("entrenar-model");
+    let model_name =
+        spec.model.path.file_name().and_then(|n| n.to_str()).unwrap_or("entrenar-model");
     println!("Saving model weights to {}...", weights_path.display());
     trainer.save(&weights_path, model_name, "LlamaForCausalLM")?;
     println!(
@@ -1647,8 +1834,13 @@ fn save_trained_model_cpu(trainer: &TransformerTrainer, spec: &TrainSpec) -> Res
         std::fs::metadata(&weights_path).map(|m| m.len()).unwrap_or(0)
     );
 
-    save_config_and_metadata(trainer.model().config(), trainer.step(),
-        &trainer.metrics, &weights_path, spec)
+    save_config_and_metadata(
+        trainer.model().config(),
+        trainer.step(),
+        &trainer.metrics,
+        &weights_path,
+        spec,
+    )
 }
 
 /// Save trained model from CUDA trainer (syncs GPU→CPU first)
@@ -1664,9 +1856,8 @@ fn save_trained_model_cuda(trainer: &mut CudaTransformerTrainer, spec: &TrainSpe
     std::fs::create_dir_all(&spec.training.output_dir).ok();
 
     let weights_path = spec.training.output_dir.join("model.safetensors");
-    let model_name = spec.model.path.file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("entrenar-model");
+    let model_name =
+        spec.model.path.file_name().and_then(|n| n.to_str()).unwrap_or("entrenar-model");
     println!("Saving model weights to {}...", weights_path.display());
     trainer.save(&weights_path, model_name, "LlamaForCausalLM")?;
     println!(
@@ -1681,8 +1872,13 @@ fn save_trained_model_cuda(trainer: &mut CudaTransformerTrainer, spec: &TrainSpe
         println!("✓ Optimizer state saved (CPU embedding m/v buffers)");
     }
 
-    save_config_and_metadata(trainer.model().config(), trainer.step(),
-        &trainer.metrics, &weights_path, spec)
+    save_config_and_metadata(
+        trainer.model().config(),
+        trainer.step(),
+        &trainer.metrics,
+        &weights_path,
+        spec,
+    )
 }
 
 /// Save config.json and metadata (shared by CPU and CUDA paths)
@@ -1989,7 +2185,9 @@ fn build_transformer_config_from_spec(spec: &TrainSpec) -> Result<TransformerCon
 
 /// Build a TransformerConfig directly from architecture overrides if all required fields are present.
 /// Required: hidden_size, num_attention_heads, num_hidden_layers, vocab_size, intermediate_size.
-fn config_from_overrides(overrides: &crate::config::ArchitectureOverrides) -> Option<TransformerConfig> {
+fn config_from_overrides(
+    overrides: &crate::config::ArchitectureOverrides,
+) -> Option<TransformerConfig> {
     let hidden_size = overrides.hidden_size?;
     let num_attention_heads = overrides.num_attention_heads?;
     let num_hidden_layers = overrides.num_hidden_layers?;
@@ -2095,9 +2293,7 @@ fn parse_hf_config(hf_config: &serde_json::Value) -> Result<TransformerConfig> {
         1e-6
     }) as f32;
     let use_bias = hf_config["attention_bias"].as_bool().unwrap_or(false);
-    let head_dim_override = hf_config["head_dim"]
-        .as_u64()
-        .map(|v| v as usize);
+    let head_dim_override = hf_config["head_dim"].as_u64().map(|v| v as usize);
 
     Ok(TransformerConfig {
         hidden_size,
@@ -2455,17 +2651,10 @@ fn load_lm_batches_from_parquet_dir(
     parquet_files.sort();
 
     if parquet_files.is_empty() {
-        return Err(Error::ConfigError(format!(
-            "No .parquet files found in {}",
-            dir.display()
-        )));
+        return Err(Error::ConfigError(format!("No .parquet files found in {}", dir.display())));
     }
 
-    println!(
-        "  Loading {} Parquet shard(s) from {}",
-        parquet_files.len(),
-        dir.display()
-    );
+    println!("  Loading {} Parquet shard(s) from {}", parquet_files.len(), dir.display());
 
     let mut all_batches = Vec::new();
     for file in &parquet_files {
@@ -2488,10 +2677,8 @@ fn try_extract_pretokenized(
 ) -> Option<Vec<Vec<u32>>> {
     use alimentar::Dataset;
 
-    let token_col = column_names
-        .iter()
-        .find(|&&n| n == "input_ids" || n == "token_ids")
-        .copied()?;
+    let token_col =
+        column_names.iter().find(|&&n| n == "input_ids" || n == "token_ids").copied()?;
 
     let schema = dataset.schema();
     let col_idx = schema.index_of(token_col).ok()?;
@@ -2503,15 +2690,16 @@ fn try_extract_pretokenized(
         extract_sequences_from_column(col, &mut all_sequences);
     }
 
-    if all_sequences.is_empty() { None } else { Some(all_sequences) }
+    if all_sequences.is_empty() {
+        None
+    } else {
+        Some(all_sequences)
+    }
 }
 
 /// Extract token sequences from a single Arrow column (List or flat integer types)
 #[cfg(all(not(target_arch = "wasm32"), feature = "parquet"))]
-fn extract_sequences_from_column(
-    col: &arrow::array::ArrayRef,
-    sequences: &mut Vec<Vec<u32>>,
-) {
+fn extract_sequences_from_column(col: &arrow::array::ArrayRef, sequences: &mut Vec<Vec<u32>>) {
     use arrow::array::{Array, ListArray};
 
     if let Some(list_arr) = col.as_any().downcast_ref::<ListArray>() {
@@ -2581,9 +2769,9 @@ fn extract_text_column(
     let col_name = resolve_text_column_name(text_column, column_names)?;
 
     let schema = dataset.schema();
-    let col_idx = schema.index_of(&col_name).map_err(|e| {
-        Error::ConfigError(format!("Column '{col_name}' not found: {e}"))
-    })?;
+    let col_idx = schema
+        .index_of(&col_name)
+        .map_err(|e| Error::ConfigError(format!("Column '{col_name}' not found: {e}")))?;
 
     let mut texts = Vec::new();
     for batch in dataset.iter() {
@@ -2630,10 +2818,7 @@ fn load_lm_batches_from_parquet(
     text_column: &str,
 ) -> Result<Vec<LMBatch>> {
     if !path.exists() {
-        return Err(Error::Io(format!(
-            "Parquet path does not exist: {}",
-            path.display()
-        )));
+        return Err(Error::Io(format!("Parquet path does not exist: {}", path.display())));
     }
     eprintln!(
         "Warning: Parquet LM loading requires the 'parquet' feature. \
@@ -3287,9 +3472,7 @@ optimizer:
         let dir = tempfile::tempdir().expect("temp dir should succeed");
         let parquet_path = dir.path().join("train.parquet");
 
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("text", DataType::Utf8, false),
-        ]));
+        let schema = Arc::new(Schema::new(vec![Field::new("text", DataType::Utf8, false)]));
         let texts = StringArray::from(vec![
             "def hello():\n    print('hello world')",
             "def add(a, b):\n    return a + b",
@@ -3307,14 +3490,8 @@ optimizer:
 
         // Load via our new implementation
         let tokenizer = HfTokenizer::qwen2();
-        let batches = load_lm_batches_from_parquet(
-            &parquet_path,
-            &tokenizer,
-            2,
-            64,
-            "text",
-        )
-        .expect("parquet loading should succeed");
+        let batches = load_lm_batches_from_parquet(&parquet_path, &tokenizer, 2, 64, "text")
+            .expect("parquet loading should succeed");
 
         assert!(!batches.is_empty());
         // 4 texts with batch_size=2 → at least 2 batches
@@ -3335,17 +3512,13 @@ optimizer:
         let shard_dir = dir.path().join("shards");
         std::fs::create_dir_all(&shard_dir).expect("dir creation should succeed");
 
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("text", DataType::Utf8, false),
-        ]));
+        let schema = Arc::new(Schema::new(vec![Field::new("text", DataType::Utf8, false)]));
 
         // Write two shard files
-        for (i, texts) in [
-            vec!["def foo(): pass", "def bar(): return 1"],
-            vec!["class A: pass", "import sys"],
-        ]
-        .iter()
-        .enumerate()
+        for (i, texts) in
+            [vec!["def foo(): pass", "def bar(): return 1"], vec!["class A: pass", "import sys"]]
+                .iter()
+                .enumerate()
         {
             let arr = StringArray::from(texts.clone());
             let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(arr)])
@@ -3359,14 +3532,8 @@ optimizer:
         }
 
         let tokenizer = HfTokenizer::qwen2();
-        let batches = load_lm_batches_from_parquet(
-            &shard_dir,
-            &tokenizer,
-            2,
-            64,
-            "text",
-        )
-        .expect("directory loading should succeed");
+        let batches = load_lm_batches_from_parquet(&shard_dir, &tokenizer, 2, 64, "text")
+            .expect("directory loading should succeed");
 
         assert!(!batches.is_empty());
         // 4 total texts across 2 shards
@@ -3385,9 +3552,7 @@ optimizer:
         let dir = tempfile::tempdir().expect("temp dir should succeed");
         let path = dir.path().join("numeric.parquet");
 
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("numbers", DataType::Int32, false),
-        ]));
+        let schema = Arc::new(Schema::new(vec![Field::new("numbers", DataType::Int32, false)]));
         let arr = Int32Array::from(vec![1, 2, 3]);
         let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(arr)])
             .expect("batch should succeed");

--- a/src/config/validate/json_schema.rs
+++ b/src/config/validate/json_schema.rs
@@ -156,30 +156,24 @@ fn semantic_checks(value: &serde_json::Value, errors: &mut Vec<String>) {
         return;
     };
 
-    if let Some(lr) = obj
-        .get("optimizer")
-        .and_then(|o| o.get("lr"))
-        .and_then(serde_json::Value::as_f64)
+    if let Some(lr) =
+        obj.get("optimizer").and_then(|o| o.get("lr")).and_then(serde_json::Value::as_f64)
     {
         if lr <= 0.0 || lr > 1.0 {
             errors.push(format!("optimizer.lr must be in (0, 1], got {lr}"));
         }
     }
 
-    if let Some(epochs) = obj
-        .get("training")
-        .and_then(|t| t.get("epochs"))
-        .and_then(serde_json::Value::as_u64)
+    if let Some(epochs) =
+        obj.get("training").and_then(|t| t.get("epochs")).and_then(serde_json::Value::as_u64)
     {
         if epochs == 0 {
             errors.push("training.epochs must be >= 1".to_string());
         }
     }
 
-    if let Some(bs) = obj
-        .get("data")
-        .and_then(|d| d.get("batch_size"))
-        .and_then(serde_json::Value::as_u64)
+    if let Some(bs) =
+        obj.get("data").and_then(|d| d.get("batch_size")).and_then(serde_json::Value::as_u64)
     {
         if bs == 0 {
             errors.push("data.batch_size must be >= 1".to_string());

--- a/src/finetune/classification_tests.rs
+++ b/src/finetune/classification_tests.rs
@@ -217,18 +217,12 @@ fn test_class_weights_sqrt_inverse() {
     let inv_weights = compute_class_weights(&stats, ClassWeightStrategy::InverseFreq, 5);
     let inv_ratio = inv_weights[1] / inv_weights[0];
     let sqrt_ratio = weights[1] / weights[0];
-    assert!(
-        sqrt_ratio < inv_ratio,
-        "sqrt_inverse should be less extreme than inverse_freq"
-    );
+    assert!(sqrt_ratio < inv_ratio, "sqrt_inverse should be less extreme than inverse_freq");
 }
 
 #[test]
 fn test_class_weights_strategy_parse() {
-    assert_eq!(
-        "uniform".parse::<ClassWeightStrategy>().ok(),
-        Some(ClassWeightStrategy::Uniform)
-    );
+    assert_eq!("uniform".parse::<ClassWeightStrategy>().ok(), Some(ClassWeightStrategy::Uniform));
     assert_eq!(
         "inverse_freq".parse::<ClassWeightStrategy>().ok(),
         Some(ClassWeightStrategy::InverseFreq)
@@ -246,10 +240,7 @@ fn test_class_weights_strategy_aliases() {
         "inverse".parse::<ClassWeightStrategy>().ok(),
         Some(ClassWeightStrategy::InverseFreq)
     );
-    assert_eq!(
-        "sqrt".parse::<ClassWeightStrategy>().ok(),
-        Some(ClassWeightStrategy::SqrtInverse)
-    );
+    assert_eq!("sqrt".parse::<ClassWeightStrategy>().ok(), Some(ClassWeightStrategy::SqrtInverse));
 }
 
 #[test]
@@ -400,8 +391,7 @@ fn test_load_multi_label_corpus_invalid_format() {
 
 #[test]
 fn test_load_multi_label_corpus_file_not_found() {
-    let result =
-        load_multi_label_corpus(std::path::Path::new("/tmp/nonexistent_ml_xyz.jsonl"), 5);
+    let result = load_multi_label_corpus(std::path::Path::new("/tmp/nonexistent_ml_xyz.jsonl"), 5);
     assert!(result.is_err());
 }
 

--- a/src/finetune/classify_pipeline.rs
+++ b/src/finetune/classify_pipeline.rs
@@ -29,21 +29,24 @@ use crate::Tensor;
 use std::path::{Path, PathBuf};
 
 #[cfg(feature = "cuda")]
-use crate::autograd::cuda_forward::{pre_warm_forward_kernels, pre_warm_lora_backward_kernels};
-#[cfg(feature = "cuda")]
 use crate::autograd::cuda_backward::pre_warm_lora_backward_kernels as pre_warm_backward_cache_kernels;
+#[cfg(feature = "cuda")]
+use crate::autograd::cuda_forward::{pre_warm_forward_kernels, pre_warm_lora_backward_kernels};
 #[cfg(feature = "cuda")]
 use crate::autograd::cuda_optim::pre_warm_lora_adamw_kernels;
 #[cfg(feature = "cuda")]
-use crate::autograd::ops::pre_warm_realizador_gemm;
-#[cfg(feature = "cuda")]
 use crate::autograd::cuda_training::{cuda_training_available, CudaTrainer};
 #[cfg(feature = "cuda")]
-use crate::transformer::{CudaBlock, CudaBlockScratch, CudaGradWorkspace, CudaLoraGradWorkspace, CudaTransformerBlock, GpuBlockOptimizerState, GpuLoraOptimizerState};
-#[cfg(feature = "cuda")]
-use std::sync::Arc;
+use crate::autograd::ops::pre_warm_realizador_gemm;
 #[cfg(feature = "cuda")]
 use crate::gpu::guard::VramGuard;
+#[cfg(feature = "cuda")]
+use crate::transformer::{
+    CudaBlock, CudaBlockScratch, CudaGradWorkspace, CudaLoraGradWorkspace, CudaTransformerBlock,
+    GpuBlockOptimizerState, GpuLoraOptimizerState,
+};
+#[cfg(feature = "cuda")]
+use std::sync::Arc;
 #[cfg(feature = "cuda")]
 use trueno_gpu::driver::GpuBuffer;
 
@@ -144,8 +147,10 @@ pub struct HyperparamDiagnostics {
 impl HyperparamDiagnostics {
     /// Check if any diagnostic matches a contract ID.
     pub fn has_warning(&self, contract_id: &str) -> bool {
-        self.items.iter().any(|d| d.contract_id == contract_id
-            && matches!(d.severity, DiagSeverity::Warn | DiagSeverity::Error))
+        self.items.iter().any(|d| {
+            d.contract_id == contract_id
+                && matches!(d.severity, DiagSeverity::Warn | DiagSeverity::Error)
+        })
     }
 
     /// Check if there are any blocking errors.
@@ -195,11 +200,7 @@ impl ClassifyConfig {
     /// Contract: provable-contracts/contracts/entrenar/qlora-hyperparameters-v1.yaml
     pub fn qlora_default(model_params: u64) -> Self {
         // C-HP-001: lr scales with model size (Dettmers 2023 Table 9)
-        let learning_rate = if model_params <= 13_000_000_000 {
-            2e-4
-        } else {
-            1e-4
-        };
+        let learning_rate = if model_params <= 13_000_000_000 { 2e-4 } else { 1e-4 };
         let lora_rank = 16;
         Self {
             num_classes: 2,
@@ -239,7 +240,8 @@ impl ClassifyConfig {
                 severity: DiagSeverity::Warn,
                 message: format!(
                     "lr={:.0e} too low for {}B model (Dettmers 2023: use 2e-4 for ≤13B)",
-                    self.learning_rate, model_params / 1_000_000_000
+                    self.learning_rate,
+                    model_params / 1_000_000_000
                 ),
                 recommendation: "learning_rate: 0.0002".to_string(),
             });
@@ -257,7 +259,8 @@ impl ClassifyConfig {
                 ),
                 recommendation: format!(
                     "batch_size: {}, accumulation_steps: {}",
-                    self.batch_size, 16 / self.batch_size.max(1)
+                    self.batch_size,
+                    16 / self.batch_size.max(1)
                 ),
             });
         }
@@ -344,7 +347,9 @@ impl ClassifyConfig {
                 severity: DiagSeverity::Warn,
                 message: format!(
                     "epochs={} with {:.1}:1 imbalance — minority gets only {} gradient updates",
-                    self.epochs, stats.imbalance_ratio, updates_per_epoch * self.epochs
+                    self.epochs,
+                    stats.imbalance_ratio,
+                    updates_per_epoch * self.epochs
                 ),
                 recommendation: format!(
                     "epochs: 3 (minority gets {} updates)",
@@ -522,8 +527,11 @@ impl ClassifyPipeline {
         // ── GPU training state (F-CUDA-014) ────────────────────────────
         #[cfg(feature = "cuda")]
         let gpu_training = Self::try_init_gpu_training(
-            &model, model_config, classify_config.max_seq_len,
-            &cuda_trainer, &cuda_blocks,
+            &model,
+            model_config,
+            classify_config.max_seq_len,
+            &cuda_trainer,
+            &cuda_blocks,
         );
 
         // ── Shared gradient workspace (C-GRADWS-001) ────────────────────
@@ -540,11 +548,17 @@ impl ClassifyPipeline {
 
         // ── NF4 LoRA training state (ENT-153) ──────────────────────────
         #[cfg(feature = "cuda")]
-        let (cuda_lora_grad_workspace, cuda_lora_optimizer_states, cuda_lora_grad_accum) = if classify_config.quantize_nf4 {
-            Self::try_init_nf4_lora_training(&cuda_trainer, &cuda_blocks, model_config, &classify_config)
-        } else {
-            (None, None, None)
-        };
+        let (cuda_lora_grad_workspace, cuda_lora_optimizer_states, cuda_lora_grad_accum) =
+            if classify_config.quantize_nf4 {
+                Self::try_init_nf4_lora_training(
+                    &cuda_trainer,
+                    &cuda_blocks,
+                    model_config,
+                    &classify_config,
+                )
+            } else {
+                (None, None, None)
+            };
 
         // ── wgpu initialization (when CUDA unavailable) ──────────────────
         #[cfg(feature = "gpu")]
@@ -669,14 +683,17 @@ impl ClassifyPipeline {
         // ── GPU training state (F-CUDA-014) ────────────────────────────
         #[cfg(feature = "cuda")]
         let gpu_training = Self::try_init_gpu_training(
-            &model, model_config, classify_config.max_seq_len,
-            &cuda_trainer, &cuda_blocks,
+            &model,
+            model_config,
+            classify_config.max_seq_len,
+            &cuda_trainer,
+            &cuda_blocks,
         );
 
         // ── Shared gradient workspace (C-GRADWS-001) ────────────────────
         #[cfg(feature = "cuda")]
         let cuda_grad_workspace = if classify_config.quantize_nf4 {
-            None  // No grad workspace needed for frozen NF4 weights
+            None // No grad workspace needed for frozen NF4 weights
         } else {
             cuda_trainer.as_ref().and_then(|t| {
                 CudaGradWorkspace::new(t.context(), model_config)
@@ -687,11 +704,17 @@ impl ClassifyPipeline {
 
         // ── NF4 LoRA training state (ENT-153) ──────────────────────────
         #[cfg(feature = "cuda")]
-        let (cuda_lora_grad_workspace, cuda_lora_optimizer_states, cuda_lora_grad_accum) = if classify_config.quantize_nf4 {
-            Self::try_init_nf4_lora_training(&cuda_trainer, &cuda_blocks, model_config, &classify_config)
-        } else {
-            (None, None, None)
-        };
+        let (cuda_lora_grad_workspace, cuda_lora_optimizer_states, cuda_lora_grad_accum) =
+            if classify_config.quantize_nf4 {
+                Self::try_init_nf4_lora_training(
+                    &cuda_trainer,
+                    &cuda_blocks,
+                    model_config,
+                    &classify_config,
+                )
+            } else {
+                (None, None, None)
+            };
 
         // ── wgpu initialization (when CUDA unavailable) ──────────────────
         #[cfg(feature = "gpu")]
@@ -705,7 +728,10 @@ impl ClassifyPipeline {
                 // KAIZEN-015: Pre-upload FFN weights to GPU
                 match crate::transformer::WgpuForwardPass::with_resident_weights(&model) {
                     Ok(pass) => {
-                        eprintln!("[wgpu] Batched forward pass initialized ({} layers, resident weights)", model_config.num_hidden_layers);
+                        eprintln!(
+                            "[wgpu] Batched forward pass initialized ({} layers, resident weights)",
+                            model_config.num_hidden_layers
+                        );
                         Some(pass)
                     }
                     Err(e) => {
@@ -788,13 +814,11 @@ impl ClassifyPipeline {
 
         // CONTRACT: Training requires a BPE tokenizer — byte-fallback is not acceptable.
         let tokenizer = {
-            let sibling = apr_path
-                .file_stem()
-                .and_then(|stem| {
-                    apr_path
-                        .parent()
-                        .map(|p| p.join(format!("{}.tokenizer.json", stem.to_str().unwrap_or(""))))
-                });
+            let sibling = apr_path.file_stem().and_then(|stem| {
+                apr_path
+                    .parent()
+                    .map(|p| p.join(format!("{}.tokenizer.json", stem.to_str().unwrap_or(""))))
+            });
 
             match sibling {
                 Some(ref path) if path.exists() => {
@@ -827,8 +851,11 @@ impl ClassifyPipeline {
 
         #[cfg(feature = "cuda")]
         let gpu_training = Self::try_init_gpu_training(
-            &model, model_config, classify_config.max_seq_len,
-            &cuda_trainer, &cuda_blocks,
+            &model,
+            model_config,
+            classify_config.max_seq_len,
+            &cuda_trainer,
+            &cuda_blocks,
         );
 
         #[cfg(feature = "cuda")]
@@ -843,11 +870,17 @@ impl ClassifyPipeline {
         };
 
         #[cfg(feature = "cuda")]
-        let (cuda_lora_grad_workspace, cuda_lora_optimizer_states, cuda_lora_grad_accum) = if classify_config.quantize_nf4 {
-            Self::try_init_nf4_lora_training(&cuda_trainer, &cuda_blocks, model_config, &classify_config)
-        } else {
-            (None, None, None)
-        };
+        let (cuda_lora_grad_workspace, cuda_lora_optimizer_states, cuda_lora_grad_accum) =
+            if classify_config.quantize_nf4 {
+                Self::try_init_nf4_lora_training(
+                    &cuda_trainer,
+                    &cuda_blocks,
+                    model_config,
+                    &classify_config,
+                )
+            } else {
+                (None, None, None)
+            };
 
         // ── wgpu initialization ──────────────────────────────────────────
         #[cfg(feature = "gpu")]
@@ -954,10 +987,7 @@ impl ClassifyPipeline {
                     }
                     ids
                 };
-                TokenizedSample {
-                    token_ids,
-                    label: s.label,
-                }
+                TokenizedSample { token_ids, label: s.label }
             })
             .collect()
     }
@@ -978,7 +1008,8 @@ impl ClassifyPipeline {
 
         // ── 2. Accumulate gradients over all samples ───────────────────
         #[cfg(feature = "gpu")]
-        let (total_loss, correct) = self.try_train_batch_wgpu_tokenized(samples)
+        let (total_loss, correct) = self
+            .try_train_batch_wgpu_tokenized(samples)
             .unwrap_or_else(|| self.train_batch_per_sample_tokenized(samples));
 
         #[cfg(not(feature = "gpu"))]
@@ -1044,26 +1075,27 @@ impl ClassifyPipeline {
 
     /// Batched wgpu forward with pre-tokenized IDs (KAIZEN-028).
     #[cfg(feature = "gpu")]
-    fn try_train_batch_wgpu_tokenized(&mut self, samples: &[TokenizedSample]) -> Option<(f32, usize)> {
+    fn try_train_batch_wgpu_tokenized(
+        &mut self,
+        samples: &[TokenizedSample],
+    ) -> Option<(f32, usize)> {
         if self.wgpu_forward_pass.is_none() {
             return None;
         }
 
-        let batch_token_ids: Vec<Vec<u32>> = samples
-            .iter()
-            .map(|s| s.token_ids.clone())
-            .collect();
+        let batch_token_ids: Vec<Vec<u32>> = samples.iter().map(|s| s.token_ids.clone()).collect();
 
-        let lora_ref = if self.lora_layers.is_empty() {
-            None
-        } else {
-            Some(self.lora_layers.as_slice())
-        };
+        let lora_ref =
+            if self.lora_layers.is_empty() { None } else { Some(self.lora_layers.as_slice()) };
 
-        let hiddens = self.wgpu_forward_pass.as_ref()
+        let hiddens = self
+            .wgpu_forward_pass
+            .as_ref()
             .expect("checked is_none above")
             .forward_hidden_batch(&self.model, &batch_token_ids, lora_ref)
-            .map_err(|e| eprintln!("[wgpu] Batched forward failed, falling back to per-sample: {e}"))
+            .map_err(|e| {
+                eprintln!("[wgpu] Batched forward failed, falling back to per-sample: {e}")
+            })
             .ok()?;
 
         let mut total_loss = 0.0f32;
@@ -1085,7 +1117,10 @@ impl ClassifyPipeline {
     /// Accumulate gradients with pre-tokenized samples (KAIZEN-028).
     ///
     /// Identical to [`accumulate_gradients`] but uses pre-tokenized IDs.
-    pub fn accumulate_gradients_tokenized(&mut self, micro_batch: &[TokenizedSample]) -> BatchResult {
+    pub fn accumulate_gradients_tokenized(
+        &mut self,
+        micro_batch: &[TokenizedSample],
+    ) -> BatchResult {
         if micro_batch.is_empty() {
             return BatchResult { avg_loss: 0.0, correct: 0, total: 0, grad_norm: 0.0 };
         }
@@ -1196,7 +1231,9 @@ impl ClassifyPipeline {
         }
 
         if quantize_nf4 {
-            eprintln!("[CUDA] NF4 quantization enabled — frozen weights will be 4-bit (~8x compression)");
+            eprintln!(
+                "[CUDA] NF4 quantization enabled — frozen weights will be 4-bit (~8x compression)"
+            );
         }
 
         if let Err(e) = pre_warm_lora_backward_kernels(
@@ -1206,7 +1243,9 @@ impl ClassifyPipeline {
             max_seq_len,
             classify_config.lora_rank,
         ) {
-            eprintln!("[CUDA] Failed to pre-warm LoRA forward-cache backward kernels: {e} — using CPU");
+            eprintln!(
+                "[CUDA] Failed to pre-warm LoRA forward-cache backward kernels: {e} — using CPU"
+            );
             return false;
         }
 
@@ -1258,11 +1297,11 @@ impl ClassifyPipeline {
     #[cfg(feature = "cuda")]
     fn estimate_vram_mb(model_config: &TransformerConfig, config: &ClassifyConfig) -> usize {
         if config.quantize_nf4 {
-            let weight_elements = model_config.per_layer_weight_elements()
-                * model_config.num_hidden_layers;
+            let weight_elements =
+                model_config.per_layer_weight_elements() * model_config.num_hidden_layers;
             let weight_mb = weight_elements / (2 * 1024 * 1024);
-            let scratch_mb = (config.max_seq_len * model_config.hidden_size * 4 * 10)
-                / (1024 * 1024);
+            let scratch_mb =
+                (config.max_seq_len * model_config.hidden_size * 4 * 10) / (1024 * 1024);
             let overhead_mb = 512;
             weight_mb + scratch_mb + overhead_mb
         } else {
@@ -1279,11 +1318,8 @@ impl ClassifyPipeline {
         classify_config: &ClassifyConfig,
     ) -> Option<VramGuard> {
         let budget_mb = Self::estimate_vram_mb(model_config, classify_config);
-        let task_label = if classify_config.quantize_nf4 {
-            "classify-qlora"
-        } else {
-            "classify-lora"
-        };
+        let task_label =
+            if classify_config.quantize_nf4 { "classify-qlora" } else { "classify-lora" };
         match VramGuard::acquire(budget_mb, task_label) {
             Ok(guard) => {
                 eprintln!(
@@ -1314,7 +1350,8 @@ impl ClassifyPipeline {
         model_config: &TransformerConfig,
         classify_config: &ClassifyConfig,
         lora_layers: &[LoRALayer],
-    ) -> (Option<CudaTrainer>, Option<Vec<CudaBlock>>, Option<CudaBlockScratch>, Option<VramGuard>) {
+    ) -> (Option<CudaTrainer>, Option<Vec<CudaBlock>>, Option<CudaBlockScratch>, Option<VramGuard>)
+    {
         if !cuda_training_available() {
             eprintln!("[CUDA] No CUDA runtime detected — using CPU");
             return (None, None, None, None);
@@ -1413,12 +1450,20 @@ impl ClassifyPipeline {
                     Arc::clone(&ctx),
                     input_norm,
                     post_attn_norm,
-                    w_q, w_k, w_v, w_o,
-                    w_gate, w_up, w_down,
+                    w_q,
+                    w_k,
+                    w_v,
+                    w_o,
+                    w_gate,
+                    w_up,
+                    w_down,
                     max_seq_len,
-                    q_lora, v_lora,
-                    lora_scale, lora_rank,
-                ).map(CudaBlock::Nf4)
+                    q_lora,
+                    v_lora,
+                    lora_scale,
+                    lora_rank,
+                )
+                .map(CudaBlock::Nf4)
             } else {
                 CudaTransformerBlock::new(
                     model_config,
@@ -1426,10 +1471,16 @@ impl ClassifyPipeline {
                     Arc::clone(&ctx),
                     input_norm,
                     post_attn_norm,
-                    w_q, w_k, w_v, w_o,
-                    w_gate, w_up, w_down,
+                    w_q,
+                    w_k,
+                    w_v,
+                    w_o,
+                    w_gate,
+                    w_up,
+                    w_down,
                     max_seq_len,
-                ).map(CudaBlock::Fp32)
+                )
+                .map(CudaBlock::Fp32)
             };
 
             match result {
@@ -1454,7 +1505,8 @@ impl ClassifyPipeline {
 
         // C-SCRATCH-001: Allocate one shared scratch for NF4 (saves 7.5 GB for Qwen3-4B)
         let shared_scratch = if quantize_nf4 {
-            match CudaBlockScratch::new(model_config, max_seq_len, &ctx, classify_config.lora_rank) {
+            match CudaBlockScratch::new(model_config, max_seq_len, &ctx, classify_config.lora_rank)
+            {
                 Ok(s) => Some(s),
                 Err(e) => {
                     eprintln!("[CUDA] Failed to allocate shared scratch: {e} — using CPU");
@@ -1568,7 +1620,9 @@ impl ClassifyPipeline {
                 match block.init_optimizer_state() {
                     Ok(state) => optimizer_states.push(state),
                     Err(e) => {
-                        eprintln!("[CUDA] GPU training init failed (optimizer state layer {i}): {e}");
+                        eprintln!(
+                            "[CUDA] GPU training init failed (optimizer state layer {i}): {e}"
+                        );
                         return None;
                     }
                 }
@@ -1581,7 +1635,10 @@ impl ClassifyPipeline {
             if is_nf4 {
                 " (NF4 QLoRA mode — LoRA optimizer separate)".to_string()
             } else {
-                format!(" ({:.1} MB optimizer state)", (optimizer_states.len() * 18 * buf_size * 4) as f64 / 1e6)
+                format!(
+                    " ({:.1} MB optimizer state)",
+                    (optimizer_states.len() * 18 * buf_size * 4) as f64 / 1e6
+                )
             }
         );
 
@@ -1632,7 +1689,11 @@ impl ClassifyPipeline {
         cuda_blocks: &Option<Vec<CudaBlock>>,
         model_config: &TransformerConfig,
         classify_config: &ClassifyConfig,
-    ) -> (Option<CudaLoraGradWorkspace>, Option<Vec<GpuLoraOptimizerState>>, Option<Vec<CudaLoraGradWorkspace>>) {
+    ) -> (
+        Option<CudaLoraGradWorkspace>,
+        Option<Vec<GpuLoraOptimizerState>>,
+        Option<Vec<CudaLoraGradWorkspace>>,
+    ) {
         let trainer = match cuda_trainer.as_ref() {
             Some(t) => t,
             None => return (None, None, None),
@@ -1644,7 +1705,9 @@ impl ClassifyPipeline {
 
         // Allocate shared LoRA gradient workspace
         let grad_ws = match CudaLoraGradWorkspace::new(
-            trainer.context(), model_config, classify_config.lora_rank,
+            trainer.context(),
+            model_config,
+            classify_config.lora_rank,
         ) {
             Ok(ws) => ws,
             Err(e) => {
@@ -1669,7 +1732,9 @@ impl ClassifyPipeline {
         let mut grad_accum = Vec::with_capacity(blocks.len());
         for i in 0..blocks.len() {
             match CudaLoraGradWorkspace::new(
-                trainer.context(), model_config, classify_config.lora_rank,
+                trainer.context(),
+                model_config,
+                classify_config.lora_rank,
             ) {
                 Ok(ws) => grad_accum.push(ws),
                 Err(e) => {
@@ -1758,9 +1823,7 @@ impl ClassifyPipeline {
             // SAFETY: Both buffers are valid GPU allocations with matching sizes.
             // The copy completes before block.forward() reads from input.
             unsafe {
-                training_state.layer_inputs[i]
-                    .copy_from_buffer_async(input, stream)
-                    .ok()?;
+                training_state.layer_inputs[i].copy_from_buffer_async(input, stream).ok()?;
             }
 
             if let Err(e) = block.forward(input, output, seq_len, stream, shared_scratch.as_mut()) {
@@ -1771,15 +1834,17 @@ impl ClassifyPipeline {
         }
         // After loop: the buffer indicated by input_is_a holds the final output
         let final_output = unsafe {
-            if input_is_a { &*scratch_a_ptr } else { &*scratch_b_ptr }
+            if input_is_a {
+                &*scratch_a_ptr
+            } else {
+                &*scratch_b_ptr
+            }
         };
 
         // Save blocks output for final norm backward
         // SAFETY: Both buffers valid, copy completes before any read.
         unsafe {
-            training_state.blocks_output
-                .copy_from_buffer_async(final_output, stream)
-                .ok()?;
+            training_state.blocks_output.copy_from_buffer_async(final_output, stream).ok()?;
         }
 
         // Sync and download for CPU classifier path
@@ -1813,11 +1878,7 @@ impl ClassifyPipeline {
     /// - **Invariant**: Zero GPU memory allocation during backward; all buffers preallocated
     #[cfg(feature = "cuda")]
     #[allow(unsafe_code)]
-    fn backward_gpu_blocks(
-        &mut self,
-        grad_logits: &[f32],
-        seq_len: usize,
-    ) -> Option<()> {
+    fn backward_gpu_blocks(&mut self, grad_logits: &[f32], seq_len: usize) -> Option<()> {
         let grad_ws = self.cuda_grad_workspace.as_mut()?;
         let trainer = self.cuda_trainer.as_ref()?;
         let hidden_size = self.model.config.hidden_size;
@@ -1847,9 +1908,10 @@ impl ClassifyPipeline {
 
         // Step 3: Upload gradient to pre-allocated GPU buffer (KAIZEN-045)
         let stream = trainer.stream();
-        training_state.grad_upload_buf.copy_from_host_at(
-            &training_state.backward_cpu_staging[..seq_len * hidden_size], 0
-        ).ok()?;
+        training_state
+            .grad_upload_buf
+            .copy_from_host_at(&training_state.backward_cpu_staging[..seq_len * hidden_size], 0)
+            .ok()?;
 
         let blocks = self.cuda_blocks.as_mut()?;
 
@@ -1866,7 +1928,8 @@ impl ClassifyPipeline {
             hidden_size as u32,
             1e-5_f32,
             stream,
-        ).ok()?;
+        )
+        .ok()?;
 
         // Step 5: Backward through blocks in reverse
         // grad_buf_a has the gradient w.r.t. blocks_output (= grad for last block's output)
@@ -1892,14 +1955,16 @@ impl ClassifyPipeline {
                 }
             };
 
-            blocks[layer_idx].backward(
-                &training_state.layer_inputs[layer_idx],
-                grad_output,
-                grad_input,
-                seq_len,
-                stream,
-                grad_ws,
-            ).ok()?;
+            blocks[layer_idx]
+                .backward(
+                    &training_state.layer_inputs[layer_idx],
+                    grad_output,
+                    grad_input,
+                    seq_len,
+                    stream,
+                    grad_ws,
+                )
+                .ok()?;
 
             grad_output_is_a = !grad_output_is_a;
         }
@@ -1928,16 +1993,17 @@ impl ClassifyPipeline {
         training_state.step += 1;
         let step = training_state.step;
 
-        for (block, opt_state) in blocks.iter_mut().zip(training_state.optimizer_states.iter_mut()) {
-            block.optimizer_step(
-                opt_state, step, lr,
-                0.9,    // beta1
-                0.999,  // beta2
-                1e-8,   // eps
-                0.01,   // weight_decay
-                stream,
-                grad_ws,
-            ).ok()?;
+        for (block, opt_state) in blocks.iter_mut().zip(training_state.optimizer_states.iter_mut())
+        {
+            block
+                .optimizer_step(
+                    opt_state, step, lr, 0.9,   // beta1
+                    0.999, // beta2
+                    1e-8,  // eps
+                    0.01,  // weight_decay
+                    stream, grad_ws,
+                )
+                .ok()?;
         }
 
         // Sync to ensure all optimizer kernels completed
@@ -1961,11 +2027,7 @@ impl ClassifyPipeline {
     /// - **Invariant**: Zero GPU memory allocation during backward
     #[cfg(feature = "cuda")]
     #[allow(unsafe_code)]
-    fn backward_nf4_gpu_blocks(
-        &mut self,
-        grad_logits: &[f32],
-        seq_len: usize,
-    ) -> Option<()> {
+    fn backward_nf4_gpu_blocks(&mut self, grad_logits: &[f32], seq_len: usize) -> Option<()> {
         use crate::transformer::cuda_block::cuda_add_inplace;
 
         let trainer = self.cuda_trainer.as_ref()?;
@@ -1995,9 +2057,10 @@ impl ClassifyPipeline {
 
         // Step 3: Upload gradient to pre-allocated GPU buffer (KAIZEN-045)
         let stream = trainer.stream();
-        training_state.grad_upload_buf.copy_from_host_at(
-            &training_state.backward_cpu_staging[..seq_len * hidden_size], 0
-        ).ok()?;
+        training_state
+            .grad_upload_buf
+            .copy_from_host_at(&training_state.backward_cpu_staging[..seq_len * hidden_size], 0)
+            .ok()?;
 
         let blocks = self.cuda_blocks.as_mut()?;
         let shared_scratch = self.shared_scratch.as_mut()?;
@@ -2015,7 +2078,8 @@ impl ClassifyPipeline {
             hidden_size as u32,
             1e-5_f32,
             stream,
-        ).ok()?;
+        )
+        .ok()?;
 
         // Step 5: Backward through blocks in reverse, accumulate gradients (KAIZEN-014)
         let num_layers = blocks.len();
@@ -2040,26 +2104,64 @@ impl ClassifyPipeline {
 
             // NF4 backward: activation checkpointing + LoRA gradient computation
             // SAFETY: output_scratch_ptr points to a disjoint field of training_state.
-            blocks[layer_idx].backward_nf4(
-                &training_state.layer_inputs[layer_idx],
-                grad_output,
-                grad_input,
-                unsafe { &mut *output_scratch_ptr },
-                seq_len,
-                stream,
-                shared_scratch,
-                grad_lora,
-            ).ok()?;
+            blocks[layer_idx]
+                .backward_nf4(
+                    &training_state.layer_inputs[layer_idx],
+                    grad_output,
+                    grad_input,
+                    unsafe { &mut *output_scratch_ptr },
+                    seq_len,
+                    stream,
+                    shared_scratch,
+                    grad_lora,
+                )
+                .ok()?;
 
             // KAIZEN-014: Accumulate gradients into per-layer accumulators
             // (grad_lora workspace is shared — must consume before next layer overwrites)
             let accum = &mut grad_accum[layer_idx];
-            cuda_add_inplace(&mut accum.grad_lora_a_q, &grad_lora.grad_lora_a_q, grad_lora.grad_lora_a_q.len(), stream).ok()?;
-            cuda_add_inplace(&mut accum.grad_lora_b_q, &grad_lora.grad_lora_b_q, grad_lora.grad_lora_b_q.len(), stream).ok()?;
-            cuda_add_inplace(&mut accum.grad_lora_a_v, &grad_lora.grad_lora_a_v, grad_lora.grad_lora_a_v.len(), stream).ok()?;
-            cuda_add_inplace(&mut accum.grad_lora_b_v, &grad_lora.grad_lora_b_v, grad_lora.grad_lora_b_v.len(), stream).ok()?;
-            cuda_add_inplace(&mut accum.grad_input_norm, &grad_lora.grad_input_norm, grad_lora.grad_input_norm.len(), stream).ok()?;
-            cuda_add_inplace(&mut accum.grad_post_attn_norm, &grad_lora.grad_post_attn_norm, grad_lora.grad_post_attn_norm.len(), stream).ok()?;
+            cuda_add_inplace(
+                &mut accum.grad_lora_a_q,
+                &grad_lora.grad_lora_a_q,
+                grad_lora.grad_lora_a_q.len(),
+                stream,
+            )
+            .ok()?;
+            cuda_add_inplace(
+                &mut accum.grad_lora_b_q,
+                &grad_lora.grad_lora_b_q,
+                grad_lora.grad_lora_b_q.len(),
+                stream,
+            )
+            .ok()?;
+            cuda_add_inplace(
+                &mut accum.grad_lora_a_v,
+                &grad_lora.grad_lora_a_v,
+                grad_lora.grad_lora_a_v.len(),
+                stream,
+            )
+            .ok()?;
+            cuda_add_inplace(
+                &mut accum.grad_lora_b_v,
+                &grad_lora.grad_lora_b_v,
+                grad_lora.grad_lora_b_v.len(),
+                stream,
+            )
+            .ok()?;
+            cuda_add_inplace(
+                &mut accum.grad_input_norm,
+                &grad_lora.grad_input_norm,
+                grad_lora.grad_input_norm.len(),
+                stream,
+            )
+            .ok()?;
+            cuda_add_inplace(
+                &mut accum.grad_post_attn_norm,
+                &grad_lora.grad_post_attn_norm,
+                grad_lora.grad_post_attn_norm.len(),
+                stream,
+            )
+            .ok()?;
 
             grad_output_is_a = !grad_output_is_a;
         }
@@ -2096,20 +2198,31 @@ impl ClassifyPipeline {
         // KAIZEN-043: Pre-allocate a single zero buffer sized to the largest
         // accumulator. Reuse via slicing instead of allocating vec![0.0; len]
         // per buffer per layer (was: 216 allocations/batch for 36 layers × 6 bufs).
-        let max_accum_len = grad_accum.iter().map(|g| {
-            g.grad_lora_a_q.len()
-                .max(g.grad_lora_b_q.len())
-                .max(g.grad_lora_a_v.len())
-                .max(g.grad_lora_b_v.len())
-                .max(g.grad_input_norm.len())
-                .max(g.grad_post_attn_norm.len())
-        }).max().unwrap_or(0);
+        let max_accum_len = grad_accum
+            .iter()
+            .map(|g| {
+                g.grad_lora_a_q
+                    .len()
+                    .max(g.grad_lora_b_q.len())
+                    .max(g.grad_lora_a_v.len())
+                    .max(g.grad_lora_b_v.len())
+                    .max(g.grad_input_norm.len())
+                    .max(g.grad_post_attn_norm.len())
+            })
+            .max()
+            .unwrap_or(0);
         let zeros = vec![0.0f32; max_accum_len];
 
         for layer_idx in 0..blocks.len() {
             let _ = blocks[layer_idx].lora_optimizer_step(
                 &mut opt_states[layer_idx],
-                step, lr, 0.9, 0.999, 1e-8, 0.01, stream,
+                step,
+                lr,
+                0.9,
+                0.999,
+                1e-8,
+                0.01,
+                stream,
                 &grad_accum[layer_idx],
             );
 
@@ -2201,11 +2314,13 @@ impl ClassifyPipeline {
 
                 if q_lora_idx < self.lora_layers.len() {
                     *self.lora_layers[q_lora_idx].lora_a_mut() = Tensor::from_vec(a_q, true);
-                    *self.lora_layers[q_lora_idx].lora_b_mut() = Tensor::from_vec(b_q_unscaled, true);
+                    *self.lora_layers[q_lora_idx].lora_b_mut() =
+                        Tensor::from_vec(b_q_unscaled, true);
                 }
                 if v_lora_idx < self.lora_layers.len() {
                     *self.lora_layers[v_lora_idx].lora_a_mut() = Tensor::from_vec(a_v, true);
-                    *self.lora_layers[v_lora_idx].lora_b_mut() = Tensor::from_vec(b_v_unscaled, true);
+                    *self.lora_layers[v_lora_idx].lora_b_mut() =
+                        Tensor::from_vec(b_v_unscaled, true);
                 }
             }
         }
@@ -2269,7 +2384,10 @@ impl ClassifyPipeline {
             };
             let mut training = self.gpu_training.take();
             let result = Self::forward_hidden_cuda_training(
-                &self.model, token_ids, trainer, blocks,
+                &self.model,
+                token_ids,
+                trainer,
+                blocks,
                 training.as_mut().expect("gpu_training was Some"),
                 &mut self.shared_scratch,
             );
@@ -2286,7 +2404,13 @@ impl ClassifyPipeline {
             (Some(ref t), Some(ref mut b)) => (t, b),
             _ => return None,
         };
-        match Self::forward_hidden_cuda_impl(&self.model, token_ids, trainer, blocks, &mut self.shared_scratch) {
+        match Self::forward_hidden_cuda_impl(
+            &self.model,
+            token_ids,
+            trainer,
+            blocks,
+            &mut self.shared_scratch,
+        ) {
             Some(tensor) => Some(tensor),
             None => {
                 self.cuda_nan_count += 1;
@@ -2335,7 +2459,9 @@ impl ClassifyPipeline {
         // Step 3: Run through CUDA transformer blocks
         let stream = trainer.stream();
         for (i, block) in cuda_blocks.iter_mut().enumerate() {
-            if let Err(e) = block.forward(&gpu_input, &mut gpu_output, seq_len, stream, shared_scratch.as_mut()) {
+            if let Err(e) =
+                block.forward(&gpu_input, &mut gpu_output, seq_len, stream, shared_scratch.as_mut())
+            {
                 eprintln!("[CUDA] Layer {i} forward failed: {e}");
                 return None;
             }
@@ -2395,7 +2521,9 @@ impl ClassifyPipeline {
     pub fn gpu_total_memory(&self) -> Option<usize> {
         #[cfg(feature = "cuda")]
         {
-            self.cuda_trainer.as_ref().map(crate::autograd::cuda_training::CudaTrainer::total_memory)
+            self.cuda_trainer
+                .as_ref()
+                .map(crate::autograd::cuda_training::CudaTrainer::total_memory)
         }
         #[cfg(not(feature = "cuda"))]
         {
@@ -2525,9 +2653,13 @@ impl ClassifyPipeline {
         // KAIZEN-011: Include LoRA in CPU optimizer when NOT on CUDA
         let has_cuda_training = {
             #[cfg(feature = "cuda")]
-            { self.gpu_training.is_some() }
+            {
+                self.gpu_training.is_some()
+            }
             #[cfg(not(feature = "cuda"))]
-            { false }
+            {
+                false
+            }
         };
         let mut params: Vec<&mut Tensor> = Vec::new();
         if !self.config.quantize_nf4 || !has_cuda_training {
@@ -2577,7 +2709,8 @@ impl ClassifyPipeline {
         // ── 2. Accumulate gradients over all samples ───────────────────
         // KAIZEN-008: try batched wgpu forward (uploads FFN weights ONCE per layer)
         #[cfg(feature = "gpu")]
-        let (total_loss, correct) = self.try_train_batch_wgpu(samples)
+        let (total_loss, correct) = self
+            .try_train_batch_wgpu(samples)
             .unwrap_or_else(|| self.train_batch_per_sample(samples));
 
         #[cfg(not(feature = "gpu"))]
@@ -2620,9 +2753,13 @@ impl ClassifyPipeline {
         // fp32 mode: LoRA + classifier head always on CPU
         let has_cuda_training = {
             #[cfg(feature = "cuda")]
-            { self.gpu_training.is_some() }
+            {
+                self.gpu_training.is_some()
+            }
             #[cfg(not(feature = "cuda"))]
-            { false }
+            {
+                false
+            }
         };
         let mut params: Vec<&mut Tensor> = Vec::new();
         if !self.config.quantize_nf4 || !has_cuda_training {
@@ -2672,22 +2809,21 @@ impl ClassifyPipeline {
             return None;
         }
 
-        let batch_token_ids: Vec<Vec<u32>> = samples
-            .iter()
-            .map(|s| self.tokenize(&s.input))
-            .collect();
+        let batch_token_ids: Vec<Vec<u32>> =
+            samples.iter().map(|s| self.tokenize(&s.input)).collect();
 
         // KAIZEN-010: Pass LoRA layers so gradients flow through Q/V adapters
-        let lora_ref = if self.lora_layers.is_empty() {
-            None
-        } else {
-            Some(self.lora_layers.as_slice())
-        };
+        let lora_ref =
+            if self.lora_layers.is_empty() { None } else { Some(self.lora_layers.as_slice()) };
 
-        let hiddens = self.wgpu_forward_pass.as_ref()
+        let hiddens = self
+            .wgpu_forward_pass
+            .as_ref()
             .expect("checked is_none above")
             .forward_hidden_batch(&self.model, &batch_token_ids, lora_ref)
-            .map_err(|e| eprintln!("[wgpu] Batched forward failed, falling back to per-sample: {e}"))
+            .map_err(|e| {
+                eprintln!("[wgpu] Batched forward failed, falling back to per-sample: {e}")
+            })
             .ok()?;
 
         let mut total_loss = 0.0f32;
@@ -2817,9 +2953,13 @@ impl ClassifyPipeline {
         let orig_seq_len = token_ids.len().min(self.config.max_seq_len);
         let has_gpu_training = {
             #[cfg(feature = "cuda")]
-            { self.gpu_training.is_some() }
+            {
+                self.gpu_training.is_some()
+            }
             #[cfg(not(feature = "cuda"))]
-            { false }
+            {
+                false
+            }
         };
         // KAIZEN-035: Avoid token_ids.to_vec() on CPU path — borrow directly.
         let hidden = if has_gpu_training {
@@ -3051,9 +3191,13 @@ impl ClassifyPipeline {
         let orig_seq_len = token_ids.len().min(self.config.max_seq_len);
         let has_gpu_training = {
             #[cfg(feature = "cuda")]
-            { self.gpu_training.is_some() }
+            {
+                self.gpu_training.is_some()
+            }
             #[cfg(not(feature = "cuda"))]
-            { false }
+            {
+                false
+            }
         };
         // KAIZEN-035: Avoid token_ids.to_vec() on CPU path — borrow directly.
         let hidden = if has_gpu_training {
@@ -3387,34 +3531,34 @@ impl ClassifyPipeline {
         for lora in &self.lora_layers {
             let a_len = lora.lora_a().data().len();
             if offset + a_len <= averaged_grads.len() {
-                lora.lora_a().set_grad(
-                    ndarray::Array1::from_vec(averaged_grads[offset..offset + a_len].to_vec()),
-                );
+                lora.lora_a().set_grad(ndarray::Array1::from_vec(
+                    averaged_grads[offset..offset + a_len].to_vec(),
+                ));
             }
             offset += a_len;
 
             let b_len = lora.lora_b().data().len();
             if offset + b_len <= averaged_grads.len() {
-                lora.lora_b().set_grad(
-                    ndarray::Array1::from_vec(averaged_grads[offset..offset + b_len].to_vec()),
-                );
+                lora.lora_b().set_grad(ndarray::Array1::from_vec(
+                    averaged_grads[offset..offset + b_len].to_vec(),
+                ));
             }
             offset += b_len;
         }
 
         let w_len = self.classifier.weight.data().len();
         if offset + w_len <= averaged_grads.len() {
-            self.classifier.weight.set_grad(
-                ndarray::Array1::from_vec(averaged_grads[offset..offset + w_len].to_vec()),
-            );
+            self.classifier.weight.set_grad(ndarray::Array1::from_vec(
+                averaged_grads[offset..offset + w_len].to_vec(),
+            ));
         }
         offset += w_len;
 
         let b_len = self.classifier.bias.data().len();
         if offset + b_len <= averaged_grads.len() {
-            self.classifier.bias.set_grad(
-                ndarray::Array1::from_vec(averaged_grads[offset..offset + b_len].to_vec()),
-            );
+            self.classifier.bias.set_grad(ndarray::Array1::from_vec(
+                averaged_grads[offset..offset + b_len].to_vec(),
+            ));
         }
 
         // Now run optimizer step with the averaged gradients

--- a/src/finetune/classify_trainer.rs
+++ b/src/finetune/classify_trainer.rs
@@ -195,7 +195,8 @@ impl ClassifyTrainer {
             Self::auto_balance_classes(&mut pipeline, &corpus);
         }
 
-        let (mut train_data, val_data) = Self::split_dataset(&corpus, config.val_split, config.seed);
+        let (mut train_data, val_data) =
+            Self::split_dataset(&corpus, config.val_split, config.seed);
 
         if config.oversample_minority {
             Self::oversample_training_data(&mut train_data, config.seed);
@@ -263,7 +264,7 @@ impl ClassifyTrainer {
     /// Threshold: if max_count / min_count > 2.0, imbalance is detected.
     /// Strategy: `SqrtInverse` (moderate rebalancing, avoids overadjust).
     fn auto_balance_classes(pipeline: &mut ClassifyPipeline, corpus: &[SafetySample]) {
-        use super::classification::{corpus_stats, compute_class_weights, ClassWeightStrategy};
+        use super::classification::{compute_class_weights, corpus_stats, ClassWeightStrategy};
 
         // Skip if user explicitly configured weights
         if pipeline.config.class_weights.is_some() {
@@ -288,20 +289,16 @@ impl ClassifyTrainer {
         let imbalance_ratio = max_count as f64 / min_count as f64;
 
         if imbalance_ratio > 2.0 {
-            let weights = compute_class_weights(&stats, ClassWeightStrategy::SqrtInverse, num_classes);
+            let weights =
+                compute_class_weights(&stats, ClassWeightStrategy::SqrtInverse, num_classes);
             println!(
                 "  Auto-detected class imbalance (ratio {imbalance_ratio:.1}:1), \
                  applying sqrt-inverse weights: {weights:?}"
             );
-            println!(
-                "  Class counts: {:?} (total: {})",
-                stats.class_counts, stats.total
-            );
+            println!("  Class counts: {:?} (total: {})", stats.class_counts, stats.total);
             pipeline.config.class_weights = Some(weights);
         } else {
-            println!(
-                "  Class balance OK (ratio {imbalance_ratio:.1}:1), using uniform weights"
-            );
+            println!("  Class balance OK (ratio {imbalance_ratio:.1}:1), using uniform weights");
         }
     }
 
@@ -338,7 +335,8 @@ impl ClassifyTrainer {
         let n = train_data.len();
         let mut rng_state: u64 = seed.wrapping_mul(0x517cc1b727220a95).wrapping_add(1);
         for i in (1..n).rev() {
-            rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            rng_state =
+                rng_state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
             let j = (rng_state >> 33) as usize % (i + 1);
             train_data.swap(i, j);
         }
@@ -516,7 +514,10 @@ impl ClassifyTrainer {
     fn train_as_coordinator(&mut self) -> TrainResult {
         use super::gradient_server::GradientServer;
 
-        let dist_config = self.config.distributed.clone()
+        let dist_config = self
+            .config
+            .distributed
+            .clone()
             .expect("train_as_coordinator requires distributed config");
 
         let total_start = std::time::Instant::now();
@@ -553,7 +554,9 @@ impl ClassifyTrainer {
 
         eprintln!(
             "[coordinator] Starting training: {} epochs, {} workers, {} samples",
-            self.config.epochs, num_workers, self.train_data.len(),
+            self.config.epochs,
+            num_workers,
+            self.train_data.len(),
         );
 
         let mut epoch_metrics_vec: Vec<EpochMetrics> = Vec::with_capacity(self.config.epochs);
@@ -573,8 +576,8 @@ impl ClassifyTrainer {
 
             // KAIZEN-032: Borrow pre-tokenized data directly — no per-epoch clone.
             for (step_idx, chunk) in self.train_tokens.chunks(batch_size).enumerate() {
-                let step = epoch as u64 * (self.train_tokens.len() / batch_size) as u64
-                    + step_idx as u64;
+                let step =
+                    epoch as u64 * (self.train_tokens.len() / batch_size) as u64 + step_idx as u64;
 
                 // Send shard assignments to workers
                 if let Err(e) = server.send_shard_assignments(step) {
@@ -615,12 +618,9 @@ impl ClassifyTrainer {
                 break;
             }
 
-            let avg_loss = if total_samples > 0 {
-                total_loss / total_samples as f32
-            } else { 0.0 };
-            let accuracy = if total_samples > 0 {
-                total_correct as f32 / total_samples as f32
-            } else { 0.0 };
+            let avg_loss = if total_samples > 0 { total_loss / total_samples as f32 } else { 0.0 };
+            let accuracy =
+                if total_samples > 0 { total_correct as f32 / total_samples as f32 } else { 0.0 };
 
             // Validate on coordinator's local val set
             let (val_loss, val_accuracy) = self.validate();
@@ -628,7 +628,9 @@ impl ClassifyTrainer {
             let epoch_time_ms = epoch_start.elapsed().as_millis() as u64;
             let samples_per_sec = if epoch_time_ms > 0 {
                 total_samples as f32 / (epoch_time_ms as f32 / 1000.0)
-            } else { 0.0 };
+            } else {
+                0.0
+            };
 
             let metrics = EpochMetrics {
                 epoch,
@@ -643,7 +645,11 @@ impl ClassifyTrainer {
 
             eprintln!(
                 "[coordinator] Epoch {}: loss={:.4}, acc={:.1}%, val_loss={:.4}, val_acc={:.1}%",
-                epoch + 1, avg_loss, accuracy * 100.0, val_loss, val_accuracy * 100.0,
+                epoch + 1,
+                avg_loss,
+                accuracy * 100.0,
+                val_loss,
+                val_accuracy * 100.0,
             );
 
             if val_loss < best_val_loss {
@@ -696,11 +702,8 @@ impl ClassifyTrainer {
             let current_lr = scheduler.get_lr();
 
             let step = batch_idx + 1;
-            let acc = if total_samples > 0 {
-                total_correct as f32 / total_samples as f32
-            } else {
-                0.0
-            };
+            let acc =
+                if total_samples > 0 { total_correct as f32 / total_samples as f32 } else { 0.0 };
 
             // Emit per-batch metrics to monitor (JSON state file + optional console)
             if let Some(ref mut writer) = self.monitor_writer {
@@ -752,7 +755,10 @@ impl ClassifyTrainer {
                 let running_acc = if i > 0 { correct as f32 / (i + 1) as f32 * 100.0 } else { 0.0 };
                 eprint!(
                     "\r  Validating: {}/{} ({:.1} sam/s, acc={:.1}%)   ",
-                    i + 1, total, sam_per_sec, running_acc,
+                    i + 1,
+                    total,
+                    sam_per_sec,
+                    running_acc,
                 );
             }
         }
@@ -765,7 +771,9 @@ impl ClassifyTrainer {
         };
         eprintln!(
             "\r  Validation complete: {} samples in {:.1}s ({:.1} sam/s)              ",
-            total, val_elapsed.as_secs_f32(), val_sam_per_sec,
+            total,
+            val_elapsed.as_secs_f32(),
+            val_sam_per_sec,
         );
 
         let avg_loss = if total > 0 { total_loss / total as f32 } else { 0.0 };
@@ -940,10 +948,7 @@ impl ClassifyTrainer {
         )
         .target_qv_projections();
 
-        let base_model = self
-            .pipeline
-            .model_dir()
-            .map(|p| p.display().to_string());
+        let base_model = self.pipeline.model_dir().map(|p| p.display().to_string());
 
         let peft_config =
             crate::lora::PeftAdapterConfig::from_lora_config(&lora_config, base_model.as_deref())
@@ -958,9 +963,8 @@ impl ClassifyTrainer {
         if let Some(model_dir) = self.pipeline.model_dir() {
             let src = model_dir.join("tokenizer.json");
             if src.exists() {
-                std::fs::copy(&src, path.join("tokenizer.json")).map_err(|e| {
-                    crate::Error::Io(format!("Failed to copy tokenizer.json: {e}"))
-                })?;
+                std::fs::copy(&src, path.join("tokenizer.json"))
+                    .map_err(|e| crate::Error::Io(format!("Failed to copy tokenizer.json: {e}")))?;
             }
         }
 
@@ -987,10 +991,8 @@ impl ClassifyTrainer {
         let mut writer = AprWriter::new();
 
         // ── Schema version (F-CKPT-002) ─────────────────────────────────
-        writer.set_metadata(
-            "__checkpoint__.schema_version".to_string(),
-            serde_json::json!("1.2.0"),
-        );
+        writer
+            .set_metadata("__checkpoint__.schema_version".to_string(), serde_json::json!("1.2.0"));
 
         // ── Rich metadata ────────────────────────────────────────────────
         writer.set_metadata("model_type".to_string(), serde_json::json!("adapter"));
@@ -998,14 +1000,9 @@ impl ClassifyTrainer {
         writer.set_metadata("val_loss".to_string(), serde_json::json!(metrics.val_loss));
         writer.set_metadata("val_accuracy".to_string(), serde_json::json!(metrics.val_accuracy));
         writer.set_metadata("train_loss".to_string(), serde_json::json!(metrics.train_loss));
-        writer.set_metadata(
-            "train_accuracy".to_string(),
-            serde_json::json!(metrics.train_accuracy),
-        );
-        writer.set_metadata(
-            "architecture".to_string(),
-            serde_json::json!("qwen2_classify"),
-        );
+        writer
+            .set_metadata("train_accuracy".to_string(), serde_json::json!(metrics.train_accuracy));
+        writer.set_metadata("architecture".to_string(), serde_json::json!("qwen2_classify"));
         writer.set_metadata(
             "num_classes".to_string(),
             serde_json::json!(self.pipeline.config.num_classes),
@@ -1087,11 +1084,8 @@ impl ClassifyTrainer {
         );
 
         // Save first moments (m) and second moments (v)
-        for (i, (m_opt, v_opt)) in optimizer
-            .first_moments()
-            .iter()
-            .zip(optimizer.second_moments().iter())
-            .enumerate()
+        for (i, (m_opt, v_opt)) in
+            optimizer.first_moments().iter().zip(optimizer.second_moments().iter()).enumerate()
         {
             if let Some(m) = m_opt {
                 let m_slice = m.as_slice().expect("contiguous moment m");
@@ -1113,11 +1107,7 @@ impl ClassifyTrainer {
 
         // ── Training metadata (F-CKPT-005) ──────────────────────────────
         writer.add_tensor_f32("__training__.epoch", vec![1], &[epoch as f32]);
-        writer.add_tensor_f32(
-            "__training__.learning_rate",
-            vec![1],
-            &[metrics.learning_rate],
-        );
+        writer.add_tensor_f32("__training__.learning_rate", vec![1], &[metrics.learning_rate]);
 
         // ── NaN/Inf check (F-CKPT-007) ──────────────────────────────────
         if !weight_slice.iter().all(|v| v.is_finite()) {
@@ -1146,8 +1136,8 @@ impl ClassifyTrainer {
         }
 
         // ── Shape validation (F-CKPT-008) ────────────────────────────────
-        let expected_weight_len = self.pipeline.config.num_classes
-            * self.pipeline.model.config.hidden_size;
+        let expected_weight_len =
+            self.pipeline.config.num_classes * self.pipeline.model.config.hidden_size;
         if weight_slice.len() != expected_weight_len {
             return Err(crate::Error::Serialization(format!(
                 "F-CKPT-008: classifier.weight shape mismatch: \
@@ -1179,23 +1169,23 @@ impl ClassifyTrainer {
     ///
     /// Produces a `.adapter.apr` with zero `__training__.*` tensors.
     /// Used for publishing and inference deployment.
-    fn save_adapter_apr(&self, path: &Path, epoch: usize, metrics: &EpochMetrics) -> crate::Result<()> {
+    fn save_adapter_apr(
+        &self,
+        path: &Path,
+        epoch: usize,
+        metrics: &EpochMetrics,
+    ) -> crate::Result<()> {
         use aprender::serialization::apr::AprWriter;
 
         let mut writer = AprWriter::new();
 
-        writer.set_metadata(
-            "__checkpoint__.schema_version".to_string(),
-            serde_json::json!("1.3.0"),
-        );
+        writer
+            .set_metadata("__checkpoint__.schema_version".to_string(), serde_json::json!("1.3.0"));
         writer.set_metadata("model_type".to_string(), serde_json::json!("adapter"));
         writer.set_metadata("epoch".to_string(), serde_json::json!(epoch));
         writer.set_metadata("val_loss".to_string(), serde_json::json!(metrics.val_loss));
         writer.set_metadata("val_accuracy".to_string(), serde_json::json!(metrics.val_accuracy));
-        writer.set_metadata(
-            "architecture".to_string(),
-            serde_json::json!("qwen2_classify"),
-        );
+        writer.set_metadata("architecture".to_string(), serde_json::json!("qwen2_classify"));
         writer.set_metadata(
             "num_classes".to_string(),
             serde_json::json!(self.pipeline.config.num_classes),
@@ -1292,22 +1282,22 @@ impl ClassifyTrainer {
         }
 
         // ── Shape-config validation (F-CKPT-014) ────────────────────────
-        let expected_weight = self.pipeline.config.num_classes
-            * self.pipeline.model.config.hidden_size;
-        reader.validate_tensor_shape("classifier.weight", expected_weight).map_err(|e| {
-            crate::Error::Serialization(e)
-        })?;
-        reader.validate_tensor_shape("classifier.bias", self.pipeline.config.num_classes).map_err(|e| {
-            crate::Error::Serialization(e)
-        })?;
+        let expected_weight =
+            self.pipeline.config.num_classes * self.pipeline.model.config.hidden_size;
+        reader
+            .validate_tensor_shape("classifier.weight", expected_weight)
+            .map_err(|e| crate::Error::Serialization(e))?;
+        reader
+            .validate_tensor_shape("classifier.bias", self.pipeline.config.num_classes)
+            .map_err(|e| crate::Error::Serialization(e))?;
 
         // ── Restore classifier head (F-CKPT-013: NaN scan) ──────────────
-        let weight_data = reader.read_tensor_f32_checked("classifier.weight").map_err(|e| {
-            crate::Error::Serialization(e)
-        })?;
-        let bias_data = reader.read_tensor_f32_checked("classifier.bias").map_err(|e| {
-            crate::Error::Serialization(e)
-        })?;
+        let weight_data = reader
+            .read_tensor_f32_checked("classifier.weight")
+            .map_err(|e| crate::Error::Serialization(e))?;
+        let bias_data = reader
+            .read_tensor_f32_checked("classifier.bias")
+            .map_err(|e| crate::Error::Serialization(e))?;
 
         self.pipeline
             .classifier
@@ -1335,18 +1325,12 @@ impl ClassifyTrainer {
             if let Ok(a_data) = reader.read_tensor_f32(&a_name) {
                 let a_tensor = lora.lora_a_mut();
                 let a_buf = a_tensor.data_mut();
-                a_buf
-                    .as_slice_mut()
-                    .expect("contiguous lora_a")
-                    .copy_from_slice(&a_data);
+                a_buf.as_slice_mut().expect("contiguous lora_a").copy_from_slice(&a_data);
             }
             if let Ok(b_data) = reader.read_tensor_f32(&b_name) {
                 let b_tensor = lora.lora_b_mut();
                 let b_buf = b_tensor.data_mut();
-                b_buf
-                    .as_slice_mut()
-                    .expect("contiguous lora_b")
-                    .copy_from_slice(&b_data);
+                b_buf.as_slice_mut().expect("contiguous lora_b").copy_from_slice(&b_data);
             }
         }
 
@@ -1368,10 +1352,8 @@ impl ClassifyTrainer {
 
             match (m_exists, v_exists) {
                 (Ok(m_data), Ok(v_data)) => {
-                    optimizer
-                        .set_first_moment(i, ndarray::Array1::from_vec(m_data));
-                    optimizer
-                        .set_second_moment(i, ndarray::Array1::from_vec(v_data));
+                    optimizer.set_first_moment(i, ndarray::Array1::from_vec(m_data));
+                    optimizer.set_second_moment(i, ndarray::Array1::from_vec(v_data));
                 }
                 _ => break, // No more moment buffers
             }
@@ -1497,9 +1479,9 @@ impl ClassifyTrainer {
         let gpu_count = 1u32; // single GPU per worker for now
         let backend = "cpu"; // will be wgpu/cuda when GPU training wired
 
-        let client = super::worker_client::WorkerClient::connect(
-            dist_config, gpu_count, backend,
-        ).map_err(|e| crate::Error::ConfigError(format!("worker connect failed: {e}")))?;
+        let client =
+            super::worker_client::WorkerClient::connect(dist_config, gpu_count, backend)
+                .map_err(|e| crate::Error::ConfigError(format!("worker connect failed: {e}")))?;
 
         eprintln!(
             "[worker {}] Connected (total workers: {})",
@@ -1539,16 +1521,19 @@ impl ClassifyTrainer {
             let gradients = self.pipeline.collect_lora_gradients();
 
             // Send gradients to coordinator
-            client.send_gradients(
-                step,
-                gradients,
-                batch_result.avg_loss,
-                batch_result.correct,
-                batch_result.total,
-            ).map_err(|e| crate::Error::ConfigError(format!("gradient send failed: {e}")))?;
+            client
+                .send_gradients(
+                    step,
+                    gradients,
+                    batch_result.avg_loss,
+                    batch_result.correct,
+                    batch_result.total,
+                )
+                .map_err(|e| crate::Error::ConfigError(format!("gradient send failed: {e}")))?;
 
             // Receive averaged gradients
-            let averaged = client.receive_averaged()
+            let averaged = client
+                .receive_averaged()
                 .map_err(|e| crate::Error::ConfigError(format!("averaged receive failed: {e}")))?;
 
             // Apply averaged gradients via optimizer step
@@ -1579,7 +1564,11 @@ impl ClassifyTrainer {
     /// # Arguments
     /// * `data` - Labeled samples to evaluate on
     /// * `label_names` - Human-readable class names (length must match num_classes)
-    pub fn evaluate(&mut self, data: &[SafetySample], label_names: &[String]) -> ClassifyEvalReport {
+    pub fn evaluate(
+        &mut self,
+        data: &[SafetySample],
+        label_names: &[String],
+    ) -> ClassifyEvalReport {
         let start = std::time::Instant::now();
         let num_classes = self.pipeline.config.num_classes;
 
@@ -1590,7 +1579,8 @@ impl ClassifyTrainer {
 
         for sample in data {
             let ids = self.pipeline.tokenize(&sample.input);
-            let (loss, predicted, probs) = self.pipeline.forward_only_with_probs(&ids, sample.label);
+            let (loss, predicted, probs) =
+                self.pipeline.forward_only_with_probs(&ids, sample.label);
             total_loss += loss;
             y_true.push(sample.label);
             y_pred.push(predicted);
@@ -1686,11 +1676,7 @@ impl ClassifyEvalReport {
         eval_time_ms: u64,
     ) -> Self {
         let total_samples = y_pred.len();
-        let avg_loss = if total_samples > 0 {
-            total_loss / total_samples as f32
-        } else {
-            0.0
-        };
+        let avg_loss = if total_samples > 0 { total_loss / total_samples as f32 } else { 0.0 };
 
         let cm = ConfusionMatrix::from_predictions_with_min_classes(y_pred, y_true, num_classes);
         let metrics = MultiClassMetrics::from_confusion_matrix(&cm);
@@ -1700,10 +1686,8 @@ impl ClassifyEvalReport {
         let mcc = Self::compute_mcc(&cm, cm.n_classes(), total_samples);
         let top2_accuracy = Self::compute_top2_accuracy(all_probs, y_true, total_samples);
 
-        let confidences: Vec<f64> = all_probs
-            .iter()
-            .map(|p| f64::from(p.iter().copied().fold(0.0f32, f32::max)))
-            .collect();
+        let confidences: Vec<f64> =
+            all_probs.iter().map(|p| f64::from(p.iter().copied().fold(0.0f32, f32::max))).collect();
 
         let (mean_confidence, mean_confidence_correct, mean_confidence_wrong) =
             Self::compute_confidence_stats(&confidences, y_pred, y_true);
@@ -1769,11 +1753,9 @@ impl ClassifyEvalReport {
             .iter()
             .zip(y_true.iter())
             .filter(|(probs, &true_label)| {
-                let mut indexed: Vec<(usize, f32)> =
-                    probs.iter().copied().enumerate().collect();
+                let mut indexed: Vec<(usize, f32)> = probs.iter().copied().enumerate().collect();
                 indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-                indexed.len() >= 2
-                    && (indexed[0].0 == true_label || indexed[1].0 == true_label)
+                indexed.len() >= 2 && (indexed[0].0 == true_label || indexed[1].0 == true_label)
             })
             .count();
         correct as f64 / total as f64
@@ -1899,14 +1881,11 @@ impl ClassifyEvalReport {
         let c: f64 = (0..num_classes).map(|k| mat[k][k] as f64).sum();
 
         // p_k = column sums (predicted counts per class)
-        let p: Vec<f64> = (0..num_classes)
-            .map(|k| mat.iter().map(|row| row[k] as f64).sum())
-            .collect();
+        let p: Vec<f64> =
+            (0..num_classes).map(|k| mat.iter().map(|row| row[k] as f64).sum()).collect();
 
         // t_k = row sums (true counts per class)
-        let t: Vec<f64> = (0..num_classes)
-            .map(|k| mat[k].iter().sum::<usize>() as f64)
-            .collect();
+        let t: Vec<f64> = (0..num_classes).map(|k| mat[k].iter().sum::<usize>() as f64).collect();
 
         let sum_pk_tk: f64 = p.iter().zip(t.iter()).map(|(pk, tk)| pk * tk).sum();
         let sum_pk_sq: f64 = p.iter().map(|pk| pk * pk).sum();
@@ -1996,7 +1975,11 @@ impl ClassifyEvalReport {
                 boot_true.push(y_true[idx]);
             }
 
-            let cm = ConfusionMatrix::from_predictions_with_min_classes(&boot_pred, &boot_true, num_classes);
+            let cm = ConfusionMatrix::from_predictions_with_min_classes(
+                &boot_pred,
+                &boot_true,
+                num_classes,
+            );
             let metrics = MultiClassMetrics::from_confusion_matrix(&cm);
 
             accs.push(cm.accuracy());
@@ -2025,16 +2008,8 @@ impl ClassifyEvalReport {
     }
 
     /// Compute baseline accuracies: random and majority-class.
-    fn compute_baselines(
-        support: &[usize],
-        total: usize,
-        num_classes: usize,
-    ) -> (f64, f64) {
-        let random = if num_classes > 0 {
-            1.0 / num_classes as f64
-        } else {
-            0.0
-        };
+    fn compute_baselines(support: &[usize], total: usize, num_classes: usize) -> (f64, f64) {
+        let random = if num_classes > 0 { 1.0 / num_classes as f64 } else { 0.0 };
         let majority = if total > 0 {
             support.iter().copied().max().unwrap_or(0) as f64 / total as f64
         } else {
@@ -2122,14 +2097,33 @@ impl ClassifyEvalReport {
     }
 
     fn report_summary(&self, out: &mut String) {
-        out.push_str(&format!("\nAccuracy:       {:.4}  ({:.1}%)  95% CI [{:.4}, {:.4}]\n",
-            self.accuracy, self.accuracy * 100.0, self.ci_accuracy.0, self.ci_accuracy.1));
-        out.push_str(&format!("Top-2 accuracy: {:.4}  ({:.1}%)\n", self.top2_accuracy, self.top2_accuracy * 100.0));
-        out.push_str(&format!("Cohen's kappa:  {:.4}  ({})\n", self.cohens_kappa, Self::kappa_interpretation(self.cohens_kappa)));
-        out.push_str(&format!("MCC:            {:.4}  95% CI [{:.4}, {:.4}]\n", self.mcc, self.ci_mcc.0, self.ci_mcc.1));
-        out.push_str(&format!("Macro F1:       {:.4}  95% CI [{:.4}, {:.4}]\n",
+        out.push_str(&format!(
+            "\nAccuracy:       {:.4}  ({:.1}%)  95% CI [{:.4}, {:.4}]\n",
+            self.accuracy,
+            self.accuracy * 100.0,
+            self.ci_accuracy.0,
+            self.ci_accuracy.1
+        ));
+        out.push_str(&format!(
+            "Top-2 accuracy: {:.4}  ({:.1}%)\n",
+            self.top2_accuracy,
+            self.top2_accuracy * 100.0
+        ));
+        out.push_str(&format!(
+            "Cohen's kappa:  {:.4}  ({})\n",
+            self.cohens_kappa,
+            Self::kappa_interpretation(self.cohens_kappa)
+        ));
+        out.push_str(&format!(
+            "MCC:            {:.4}  95% CI [{:.4}, {:.4}]\n",
+            self.mcc, self.ci_mcc.0, self.ci_mcc.1
+        ));
+        out.push_str(&format!(
+            "Macro F1:       {:.4}  95% CI [{:.4}, {:.4}]\n",
             self.avg_metric(&self.per_class_f1, crate::eval::classification::Average::Macro),
-            self.ci_macro_f1.0, self.ci_macro_f1.1));
+            self.ci_macro_f1.0,
+            self.ci_macro_f1.1
+        ));
         out.push_str(&format!("Avg loss:       {:.4}\n", self.avg_loss));
     }
 
@@ -2142,10 +2136,16 @@ impl ClassifyEvalReport {
     }
 
     fn report_scoring_rules(&self, out: &mut String) {
-        out.push_str(&format!("\nBrier score:    {:.4}  (perfect=0, random={:.4})\n",
-            self.brier_score, 1.0 - 1.0 / self.num_classes as f64));
-        out.push_str(&format!("Log loss:       {:.4}  (random={:.4})\n",
-            self.log_loss, (self.num_classes as f64).ln()));
+        out.push_str(&format!(
+            "\nBrier score:    {:.4}  (perfect=0, random={:.4})\n",
+            self.brier_score,
+            1.0 - 1.0 / self.num_classes as f64
+        ));
+        out.push_str(&format!(
+            "Log loss:       {:.4}  (random={:.4})\n",
+            self.log_loss,
+            (self.num_classes as f64).ln()
+        ));
     }
 
     fn report_calibration(&self, out: &mut String) {
@@ -2159,7 +2159,11 @@ impl ClassifyEvalReport {
                 let overconf = if conf > acc { "+" } else { "" };
                 out.push_str(&format!(
                     "  [{:.1}-{:.1})  {:.4}      {:.4}      {:>5}  {overconf}{:.3}\n",
-                    lo, hi, conf, acc, count,
+                    lo,
+                    hi,
+                    conf,
+                    acc,
+                    count,
                     conf - acc,
                 ));
             }
@@ -2167,7 +2171,8 @@ impl ClassifyEvalReport {
     }
 
     fn report_baselines(&self, out: &mut String) {
-        out.push_str(&format!("\nBaselines:  random={:.1}%  majority={:.1}%  model={:.1}%  lift={:.1}x\n",
+        out.push_str(&format!(
+            "\nBaselines:  random={:.1}%  majority={:.1}%  model={:.1}%  lift={:.1}x\n",
             self.baseline_random * 100.0,
             self.baseline_majority * 100.0,
             self.accuracy * 100.0,
@@ -2189,7 +2194,10 @@ impl ClassifyEvalReport {
 
     fn report_throughput(&self, out: &mut String) {
         out.push_str(&format!("\nSamples:   {}\n", self.total_samples));
-        out.push_str(&format!("Time:      {}ms ({:.1} samples/sec)\n", self.eval_time_ms, self.samples_per_sec));
+        out.push_str(&format!(
+            "Time:      {}ms ({:.1} samples/sec)\n",
+            self.eval_time_ms, self.samples_per_sec
+        ));
     }
 
     /// Interpret Cohen's kappa value.
@@ -2336,7 +2344,9 @@ impl ClassifyEvalReport {
         out.push_str("---\n");
         out.push_str("license: apache-2.0\n");
         out.push_str("language:\n- en\n");
-        out.push_str("tags:\n- shell-safety\n- code-classification\n- lora\n- entrenar\n- security\n");
+        out.push_str(
+            "tags:\n- shell-safety\n- code-classification\n- lora\n- entrenar\n- security\n",
+        );
         if let Some(base) = base_model {
             out.push_str(&format!("base_model: {base}\n"));
         }
@@ -2349,8 +2359,12 @@ impl ClassifyEvalReport {
         out.push_str("      name: Shell Safety Classification\n");
         out.push_str("    metrics:\n");
         out.push_str(&format!("    - type: accuracy\n      value: {:.4}\n", self.accuracy));
-        out.push_str(&format!("    - type: f1\n      value: {macro_f1:.4}\n      name: Macro F1\n"));
-        out.push_str(&format!("    - type: f1\n      value: {weighted_f1:.4}\n      name: Weighted F1\n"));
+        out.push_str(&format!(
+            "    - type: f1\n      value: {macro_f1:.4}\n      name: Macro F1\n"
+        ));
+        out.push_str(&format!(
+            "    - type: f1\n      value: {weighted_f1:.4}\n      name: Weighted F1\n"
+        ));
         out.push_str(&format!("    - type: mcc\n      value: {:.4}\n", self.mcc));
         out.push_str(&format!("    - type: cohens_kappa\n      value: {:.4}\n", self.cohens_kappa));
         out.push_str("---\n\n");
@@ -2360,7 +2374,9 @@ impl ClassifyEvalReport {
         out.push_str(&format!("# {model_name}\n\n"));
         out.push_str("A shell command safety classifier that categorizes shell commands into safety classes, ");
         out.push_str("enabling automated triage of commands before execution.\n\n");
-        out.push_str("Trained with [entrenar](https://github.com/paiml/entrenar) using LoRA fine-tuning");
+        out.push_str(
+            "Trained with [entrenar](https://github.com/paiml/entrenar) using LoRA fine-tuning",
+        );
         if let Some(base) = base_model {
             out.push_str(&format!(" on [`{base}`](https://huggingface.co/{base})"));
         }
@@ -2371,13 +2387,27 @@ impl ClassifyEvalReport {
         out.push_str("## Summary\n\n");
         out.push_str("| Metric | Value | 95% CI |\n");
         out.push_str("|--------|-------|--------|\n");
-        out.push_str(&format!("| Accuracy | {:.2}% | [{:.2}%, {:.2}%] |\n",
-            self.accuracy * 100.0, self.ci_accuracy.0 * 100.0, self.ci_accuracy.1 * 100.0));
+        out.push_str(&format!(
+            "| Accuracy | {:.2}% | [{:.2}%, {:.2}%] |\n",
+            self.accuracy * 100.0,
+            self.ci_accuracy.0 * 100.0,
+            self.ci_accuracy.1 * 100.0
+        ));
         out.push_str(&format!("| Top-2 Accuracy | {:.2}% | — |\n", self.top2_accuracy * 100.0));
-        out.push_str(&format!("| Macro F1 | {macro_f1:.4} | [{:.4}, {:.4}] |\n", self.ci_macro_f1.0, self.ci_macro_f1.1));
+        out.push_str(&format!(
+            "| Macro F1 | {macro_f1:.4} | [{:.4}, {:.4}] |\n",
+            self.ci_macro_f1.0, self.ci_macro_f1.1
+        ));
         out.push_str(&format!("| Weighted F1 | {weighted_f1:.4} | — |\n"));
-        out.push_str(&format!("| Cohen's Kappa | {:.4} ({}) | — |\n", self.cohens_kappa, Self::kappa_interpretation(self.cohens_kappa)));
-        out.push_str(&format!("| MCC | {:.4} | [{:.4}, {:.4}] |\n", self.mcc, self.ci_mcc.0, self.ci_mcc.1));
+        out.push_str(&format!(
+            "| Cohen's Kappa | {:.4} ({}) | — |\n",
+            self.cohens_kappa,
+            Self::kappa_interpretation(self.cohens_kappa)
+        ));
+        out.push_str(&format!(
+            "| MCC | {:.4} | [{:.4}, {:.4}] |\n",
+            self.mcc, self.ci_mcc.0, self.ci_mcc.1
+        ));
         out.push_str(&format!("| Brier Score | {:.4} | — |\n", self.brier_score));
         out.push_str(&format!("| Log Loss | {:.4} | — |\n", self.log_loss));
         out.push_str(&format!("| ECE | {:.4} | — |\n", self.ece));
@@ -2385,10 +2415,16 @@ impl ClassifyEvalReport {
         out.push_str(&format!("| Eval Samples | {} | — |\n", self.total_samples));
         out.push_str(&format!("| Throughput | {:.1} samples/sec | — |\n\n", self.samples_per_sec));
 
-        let lift = if self.baseline_majority > 0.0 { self.accuracy / self.baseline_majority } else { 0.0 };
+        let lift =
+            if self.baseline_majority > 0.0 { self.accuracy / self.baseline_majority } else { 0.0 };
         out.push_str("**Baselines**: ");
-        out.push_str(&format!("random={:.1}%, majority={:.1}%, model={:.1}% ({:.1}x lift over majority)\n\n",
-            self.baseline_random * 100.0, self.baseline_majority * 100.0, self.accuracy * 100.0, lift));
+        out.push_str(&format!(
+            "random={:.1}%, majority={:.1}%, model={:.1}% ({:.1}x lift over majority)\n\n",
+            self.baseline_random * 100.0,
+            self.baseline_majority * 100.0,
+            self.accuracy * 100.0,
+            lift
+        ));
     }
 
     fn card_labels(&self, out: &mut String) {
@@ -2477,7 +2513,8 @@ impl ClassifyEvalReport {
     }
 
     fn card_confusion_row_label(&self, out: &mut String, i: usize) {
-        let name = self.label_names.get(i).map_or_else(|| format!("class_{i}"), std::clone::Clone::clone);
+        let name =
+            self.label_names.get(i).map_or_else(|| format!("class_{i}"), std::clone::Clone::clone);
         let short = if name.len() > 18 { &name[..18] } else { name.as_str() };
         out.push_str(&format!("{short:>18}"));
     }
@@ -2500,9 +2537,7 @@ impl ClassifyEvalReport {
             if count > 0 {
                 let lo = i as f64 * 0.1;
                 let hi = lo + 0.1;
-                out.push_str(&format!(
-                    "[{lo:.1}-{hi:.1})   {conf:.3}   {acc:.3}   {count:>5}\n",
-                ));
+                out.push_str(&format!("[{lo:.1}-{hi:.1})   {conf:.3}   {acc:.3}   {count:>5}\n",));
             }
         }
         out.push_str("```\n\n");
@@ -2526,10 +2561,16 @@ impl ClassifyEvalReport {
 
     fn card_intended_use(out: &mut String) {
         out.push_str("## Intended Use\n\n");
-        out.push_str("This model is designed for **automated shell command safety triage** in:\n\n");
-        out.push_str("- **CI/CD pipelines**: Pre-flight safety check before executing generated scripts\n");
+        out.push_str(
+            "This model is designed for **automated shell command safety triage** in:\n\n",
+        );
+        out.push_str(
+            "- **CI/CD pipelines**: Pre-flight safety check before executing generated scripts\n",
+        );
         out.push_str("- **Shell purification tools**: Classify commands to determine transformation strategy\n");
-        out.push_str("- **Code review**: Flag potentially unsafe shell commands in pull requests\n");
+        out.push_str(
+            "- **Code review**: Flag potentially unsafe shell commands in pull requests\n",
+        );
         out.push_str("- **Interactive shells**: Warn users before executing risky commands\n\n");
     }
 
@@ -2538,13 +2579,18 @@ impl ClassifyEvalReport {
         out.push_str("- **Not a security oracle**: This model provides *classification hints*, not security guarantees\n");
         out.push_str("- **Context-blind**: Cannot assess safety based on the execution environment or user permissions\n");
         out.push_str("- **Training distribution**: Trained on synthetic shell scripts; may underperform on novel patterns\n");
-        out.push_str("- **English only**: Command names and variable patterns are English-centric\n");
+        out.push_str(
+            "- **English only**: Command names and variable patterns are English-centric\n",
+        );
         self.card_weak_classes(out);
         out.push('\n');
     }
 
     fn card_weak_classes(&self, out: &mut String) {
-        let min_f1_idx = self.per_class_f1.iter().enumerate()
+        let min_f1_idx = self
+            .per_class_f1
+            .iter()
+            .enumerate()
             .min_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
             .map(|(i, _)| i);
         if let Some(idx) = min_f1_idx {
@@ -2612,13 +2658,8 @@ impl ClassifyEvalReport {
 }
 
 /// SSC label names used across the shell safety classifier.
-pub const SSC_LABELS: [&str; 5] = [
-    "safe",
-    "needs-quoting",
-    "non-deterministic",
-    "non-idempotent",
-    "unsafe",
-];
+pub const SSC_LABELS: [&str; 5] =
+    ["safe", "needs-quoting", "non-deterministic", "non-idempotent", "unsafe"];
 
 /// Evaluate a saved checkpoint against a test JSONL dataset.
 ///
@@ -2638,10 +2679,7 @@ fn restore_class_weights_from_metadata(
     let meta_str = std::fs::read_to_string(checkpoint_dir.join("metadata.json")).ok()?;
     let meta: serde_json::Value = serde_json::from_str(&meta_str).ok()?;
     let arr = meta.get("class_weights")?.as_array()?;
-    let weights: Vec<f32> = arr
-        .iter()
-        .filter_map(|v| v.as_f64().map(|f| f as f32))
-        .collect();
+    let weights: Vec<f32> = arr.iter().filter_map(|v| v.as_f64().map(|f| f as f32)).collect();
     (weights.len() == num_classes).then_some(weights)
 }
 
@@ -2681,11 +2719,10 @@ pub fn evaluate_checkpoint(
     let adapter_config_path = checkpoint_dir.join("adapter_config.json");
     let mut pipeline = if adapter_config_path.exists() {
         // LoRA adapter checkpoint: load base model, then restore adapter weights
-        let adapter_json = std::fs::read_to_string(&adapter_config_path).map_err(|e| {
-            crate::Error::Io(format!("Failed to read adapter_config.json: {e}"))
-        })?;
-        let peft_config: crate::lora::PeftAdapterConfig =
-            serde_json::from_str(&adapter_json).map_err(|e| {
+        let adapter_json = std::fs::read_to_string(&adapter_config_path)
+            .map_err(|e| crate::Error::Io(format!("Failed to read adapter_config.json: {e}")))?;
+        let peft_config: crate::lora::PeftAdapterConfig = serde_json::from_str(&adapter_json)
+            .map_err(|e| {
                 crate::Error::Serialization(format!("Invalid adapter_config.json: {e}"))
             })?;
 
@@ -2716,9 +2753,7 @@ pub fn evaluate_checkpoint(
                 )?
             }
             Some(base_model_path) => {
-                println!(
-                    "Base model path is not a SafeTensors directory: {base_model_path}"
-                );
+                println!("Base model path is not a SafeTensors directory: {base_model_path}");
                 println!("Using random-init base model (adapter weights will be restored from checkpoint)");
                 ClassifyPipeline::new(model_config, classify_config.clone())
             }
@@ -2732,9 +2767,7 @@ pub fn evaluate_checkpoint(
         // Load trained LoRA + classifier weights from checkpoint
         let st_path = checkpoint_dir.join("model.safetensors");
         let st_data = std::fs::read(&st_path).map_err(|e| {
-            crate::Error::Io(format!(
-                "Failed to read checkpoint model.safetensors: {e}"
-            ))
+            crate::Error::Io(format!("Failed to read checkpoint model.safetensors: {e}"))
         })?;
         let tensors = safetensors::SafeTensors::deserialize(&st_data).map_err(|e| {
             crate::Error::Serialization(format!("Failed to deserialize checkpoint: {e}"))
@@ -3185,10 +3218,8 @@ mod tests {
     #[test]
     fn test_training_config_with_distributed() {
         let dist = DistributedConfig::coordinator("127.0.0.1:0".parse().expect("valid"), 2);
-        let config = TrainingConfig {
-            distributed: Some(dist.clone()),
-            ..TrainingConfig::default()
-        };
+        let config =
+            TrainingConfig { distributed: Some(dist.clone()), ..TrainingConfig::default() };
         assert!(config.distributed.is_some());
         assert_eq!(config.distributed.expect("valid").expect_workers, 2);
     }
@@ -3197,10 +3228,7 @@ mod tests {
     fn test_is_coordinator_mode() {
         let pipeline = tiny_pipeline(2);
         let corpus = make_corpus(20, 2);
-        let config = TrainingConfig {
-            epochs: 1,
-            ..TrainingConfig::default()
-        };
+        let config = TrainingConfig { epochs: 1, ..TrainingConfig::default() };
         let trainer = ClassifyTrainer::new(pipeline, corpus, config).expect("valid");
         assert!(!trainer.is_coordinator_mode());
     }
@@ -3210,11 +3238,8 @@ mod tests {
         let pipeline = tiny_pipeline(2);
         let corpus = make_corpus(20, 2);
         let dist = DistributedConfig::coordinator("127.0.0.1:0".parse().expect("valid"), 1);
-        let config = TrainingConfig {
-            epochs: 1,
-            distributed: Some(dist),
-            ..TrainingConfig::default()
-        };
+        let config =
+            TrainingConfig { epochs: 1, distributed: Some(dist), ..TrainingConfig::default() };
         let trainer = ClassifyTrainer::new(pipeline, corpus, config).expect("valid");
         assert!(trainer.is_coordinator_mode());
     }
@@ -3224,11 +3249,8 @@ mod tests {
         let pipeline = tiny_pipeline(2);
         let corpus = make_corpus(20, 2);
         let dist = DistributedConfig::worker("127.0.0.1:9000".parse().expect("valid"));
-        let config = TrainingConfig {
-            epochs: 1,
-            distributed: Some(dist),
-            ..TrainingConfig::default()
-        };
+        let config =
+            TrainingConfig { epochs: 1, distributed: Some(dist), ..TrainingConfig::default() };
         let trainer = ClassifyTrainer::new(pipeline, corpus, config).expect("valid");
         assert!(!trainer.is_coordinator_mode());
     }
@@ -3288,9 +3310,7 @@ mod tests {
             let grads: Vec<f32> = (0..num_params).map(|i| (i as f32 + 1.0) * 0.01).collect();
 
             // Send gradients (simulating forward/backward output)
-            client
-                .send_gradients(0, grads, 0.5, 3, 5)
-                .expect("valid");
+            client.send_gradients(0, grads, 0.5, 3, 5).expect("valid");
 
             // Receive averaged gradients
             let averaged = client.receive_averaged().expect("valid");

--- a/src/finetune/classify_tuner.rs
+++ b/src/finetune/classify_tuner.rs
@@ -163,67 +163,71 @@ pub fn default_classify_search_space() -> HyperparameterSpace {
     let mut space = HyperparameterSpace::new();
 
     // Learning rate: 5e-6 .. 5e-4 (log-scale)
-    space.add("learning_rate", ParameterDomain::Continuous {
-        low: 5e-6,
-        high: 5e-4,
-        log_scale: true,
-    });
+    space.add(
+        "learning_rate",
+        ParameterDomain::Continuous { low: 5e-6, high: 5e-4, log_scale: true },
+    );
 
     // LoRA rank: 4 .. 64 (discrete, step of 4 → 4,8,12,...,64)
     space.add("lora_rank", ParameterDomain::Discrete { low: 1, high: 16 });
 
     // Alpha ratio: 0.5 .. 2.0 (ties alpha to rank)
-    space.add("lora_alpha_ratio", ParameterDomain::Continuous {
-        low: 0.5,
-        high: 2.0,
-        log_scale: false,
-    });
+    space.add(
+        "lora_alpha_ratio",
+        ParameterDomain::Continuous { low: 0.5, high: 2.0, log_scale: false },
+    );
 
     // Batch size: categorical [8, 16, 32, 64, 128]
-    space.add("batch_size", ParameterDomain::Categorical {
-        choices: vec![
-            "8".to_string(),
-            "16".to_string(),
-            "32".to_string(),
-            "64".to_string(),
-            "128".to_string(),
-        ],
-    });
+    space.add(
+        "batch_size",
+        ParameterDomain::Categorical {
+            choices: vec![
+                "8".to_string(),
+                "16".to_string(),
+                "32".to_string(),
+                "64".to_string(),
+                "128".to_string(),
+            ],
+        },
+    );
 
     // Warmup fraction: 0.01 .. 0.2
-    space.add("warmup_fraction", ParameterDomain::Continuous {
-        low: 0.01,
-        high: 0.2,
-        log_scale: false,
-    });
+    space.add(
+        "warmup_fraction",
+        ParameterDomain::Continuous { low: 0.01, high: 0.2, log_scale: false },
+    );
 
     // Gradient clip norm: 0.5 .. 5.0
-    space.add("gradient_clip_norm", ParameterDomain::Continuous {
-        low: 0.5,
-        high: 5.0,
-        log_scale: false,
-    });
+    space.add(
+        "gradient_clip_norm",
+        ParameterDomain::Continuous { low: 0.5, high: 5.0, log_scale: false },
+    );
 
     // Class weights strategy
-    space.add("class_weights", ParameterDomain::Categorical {
-        choices: vec![
-            "uniform".to_string(),
-            "inverse_freq".to_string(),
-            "sqrt_inverse".to_string(),
-        ],
-    });
+    space.add(
+        "class_weights",
+        ParameterDomain::Categorical {
+            choices: vec![
+                "uniform".to_string(),
+                "inverse_freq".to_string(),
+                "sqrt_inverse".to_string(),
+            ],
+        },
+    );
 
     // Target modules
-    space.add("target_modules", ParameterDomain::Categorical {
-        choices: vec!["qv".to_string(), "qkv".to_string(), "all_linear".to_string()],
-    });
+    space.add(
+        "target_modules",
+        ParameterDomain::Categorical {
+            choices: vec!["qv".to_string(), "qkv".to_string(), "all_linear".to_string()],
+        },
+    );
 
     // LR min ratio (cosine decay floor = lr * ratio)
-    space.add("lr_min_ratio", ParameterDomain::Continuous {
-        low: 0.001,
-        high: 0.1,
-        log_scale: true,
-    });
+    space.add(
+        "lr_min_ratio",
+        ParameterDomain::Continuous { low: 0.001, high: 0.1, log_scale: true },
+    );
 
     space
 }
@@ -236,22 +240,14 @@ pub fn default_classify_search_space() -> HyperparameterSpace {
 pub fn extract_trial_params(
     config: &HashMap<String, ParameterValue>,
 ) -> (f32, usize, f32, usize, f32, f32, String, String, f32) {
-    let lr = config
-        .get("learning_rate")
-        .and_then(ParameterValue::as_float)
-        .unwrap_or(1e-4) as f32;
+    let lr = config.get("learning_rate").and_then(ParameterValue::as_float).unwrap_or(1e-4) as f32;
 
     // lora_rank: discrete 1-16 maps to rank * 4 → 4,8,...,64
-    let rank_raw = config
-        .get("lora_rank")
-        .and_then(ParameterValue::as_int)
-        .unwrap_or(4) as usize;
+    let rank_raw = config.get("lora_rank").and_then(ParameterValue::as_int).unwrap_or(4) as usize;
     let rank = (rank_raw * 4).clamp(4, 64);
 
-    let alpha_ratio = config
-        .get("lora_alpha_ratio")
-        .and_then(ParameterValue::as_float)
-        .unwrap_or(1.0) as f32;
+    let alpha_ratio =
+        config.get("lora_alpha_ratio").and_then(ParameterValue::as_float).unwrap_or(1.0) as f32;
     let alpha = rank as f32 * alpha_ratio;
 
     let batch_size = config
@@ -260,15 +256,11 @@ pub fn extract_trial_params(
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or(32);
 
-    let warmup = config
-        .get("warmup_fraction")
-        .and_then(ParameterValue::as_float)
-        .unwrap_or(0.1) as f32;
+    let warmup =
+        config.get("warmup_fraction").and_then(ParameterValue::as_float).unwrap_or(0.1) as f32;
 
-    let clip = config
-        .get("gradient_clip_norm")
-        .and_then(ParameterValue::as_float)
-        .unwrap_or(1.0) as f32;
+    let clip =
+        config.get("gradient_clip_norm").and_then(ParameterValue::as_float).unwrap_or(1.0) as f32;
 
     let weights_strategy = config
         .get("class_weights")
@@ -276,16 +268,11 @@ pub fn extract_trial_params(
         .unwrap_or("uniform")
         .to_string();
 
-    let targets = config
-        .get("target_modules")
-        .and_then(ParameterValue::as_str)
-        .unwrap_or("qv")
-        .to_string();
+    let targets =
+        config.get("target_modules").and_then(ParameterValue::as_str).unwrap_or("qv").to_string();
 
-    let lr_min_ratio = config
-        .get("lr_min_ratio")
-        .and_then(ParameterValue::as_float)
-        .unwrap_or(0.01) as f32;
+    let lr_min_ratio =
+        config.get("lr_min_ratio").and_then(ParameterValue::as_float).unwrap_or(0.01) as f32;
 
     (lr, rank, alpha, batch_size, warmup, clip, weights_strategy, targets, lr_min_ratio)
 }
@@ -357,9 +344,7 @@ impl ClassifyTuner {
         self.leaderboard.push(summary);
         // Sort leaderboard by val_loss ascending (best first)
         self.leaderboard.sort_by(|a, b| {
-            a.val_loss
-                .partial_cmp(&b.val_loss)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            a.val_loss.partial_cmp(&b.val_loss).unwrap_or(std::cmp::Ordering::Equal)
         });
     }
 

--- a/src/finetune/classify_tuner_tests.rs
+++ b/src/finetune/classify_tuner_tests.rs
@@ -71,9 +71,7 @@ fn test_grid_searcher() {
     space.add("lr", ParameterDomain::Continuous { low: 1e-4, high: 1e-2, log_scale: true });
     space.add(
         "act",
-        ParameterDomain::Categorical {
-            choices: vec!["relu".to_string(), "gelu".to_string()],
-        },
+        ParameterDomain::Categorical { choices: vec!["relu".to_string(), "gelu".to_string()] },
     );
 
     let mut searcher = GridSearcher::new(space, 3);
@@ -157,10 +155,7 @@ fn test_extract_trial_params() {
         "class_weights".to_string(),
         ParameterValue::Categorical("sqrt_inverse".to_string()),
     );
-    config.insert(
-        "target_modules".to_string(),
-        ParameterValue::Categorical("qv".to_string()),
-    );
+    config.insert("target_modules".to_string(), ParameterValue::Categorical("qv".to_string()));
     config.insert("lr_min_ratio".to_string(), ParameterValue::Float(0.01));
 
     let (lr, rank, alpha, batch, warmup, clip, weights, targets, lr_min) =
@@ -398,10 +393,7 @@ fn test_grid_searcher_record_and_best() {
 #[test]
 fn test_grid_searcher_exhausted() {
     let mut space = HyperparameterSpace::new();
-    space.add(
-        "act",
-        ParameterDomain::Categorical { choices: vec!["relu".to_string()] },
-    );
+    space.add("act", ParameterDomain::Categorical { choices: vec!["relu".to_string()] });
     let mut searcher = GridSearcher::new(space, 1);
 
     // Only 1 config: should succeed once, then fail
@@ -431,8 +423,7 @@ fn test_strategy_display() {
 
 #[test]
 fn test_build_scheduler_median() {
-    let config =
-        TuneConfig { scheduler: SchedulerKind::Median, ..TuneConfig::default() };
+    let config = TuneConfig { scheduler: SchedulerKind::Median, ..TuneConfig::default() };
     let tuner = ClassifyTuner::new(config).expect("valid");
     let scheduler = tuner.build_scheduler();
     // Median scheduler with no history should not prune
@@ -441,8 +432,7 @@ fn test_build_scheduler_median() {
 
 #[test]
 fn test_build_scheduler_none() {
-    let config =
-        TuneConfig { scheduler: SchedulerKind::None, ..TuneConfig::default() };
+    let config = TuneConfig { scheduler: SchedulerKind::None, ..TuneConfig::default() };
     let tuner = ClassifyTuner::new(config).expect("valid");
     let scheduler = tuner.build_scheduler();
     assert!(!scheduler.should_stop(0, 100, 999.0));

--- a/src/finetune/data_parallel.rs
+++ b/src/finetune/data_parallel.rs
@@ -75,10 +75,7 @@ impl DataParallelCoordinator {
             pipelines.push(pipeline);
         }
 
-        Ok(Self {
-            pipelines,
-            gpu_indices: gpu_indices.to_vec(),
-        })
+        Ok(Self { pipelines, gpu_indices: gpu_indices.to_vec() })
     }
 
     /// Number of GPUs in the pool
@@ -143,8 +140,7 @@ impl DataParallelCoordinator {
         let total_correct: usize = results.iter().map(|r| r.correct).sum();
         let avg_loss: f32 =
             results.iter().map(|r| r.avg_loss * r.total as f32).sum::<f32>() / total_samples as f32;
-        let avg_grad_norm: f32 =
-            results.iter().map(|r| r.grad_norm).sum::<f32>() / num_gpus as f32;
+        let avg_grad_norm: f32 = results.iter().map(|r| r.grad_norm).sum::<f32>() / num_gpus as f32;
 
         // ── 4. Sync LoRA weights from primary to replicas ─────────────────
         // After each GPU's optimizer step, weights diverge slightly.
@@ -180,7 +176,9 @@ impl DataParallelCoordinator {
 
         for replica in replicas.iter_mut() {
             // Copy LoRA weights directly via assign (single memcpy per matrix)
-            for (src_lora, dst_lora) in primary.lora_layers.iter().zip(replica.lora_layers.iter_mut()) {
+            for (src_lora, dst_lora) in
+                primary.lora_layers.iter().zip(replica.lora_layers.iter_mut())
+            {
                 dst_lora.lora_a_mut().data_mut().assign(src_lora.lora_a().data());
                 dst_lora.lora_b_mut().data_mut().assign(src_lora.lora_b().data());
             }
@@ -208,11 +206,7 @@ pub fn shard_samples<T>(samples: &[T], num_workers: usize) -> Vec<&[T]> {
     (0..num_workers)
         .map(|i| {
             let start = i * shard_size;
-            let end = if i == num_workers - 1 {
-                samples.len()
-            } else {
-                start + shard_size
-            };
+            let end = if i == num_workers - 1 { samples.len() } else { start + shard_size };
             &samples[start..end]
         })
         .collect()
@@ -269,11 +263,8 @@ mod tests {
             head_dim_override: None,
         };
 
-        let classify_config = ClassifyConfig {
-            num_classes: 2,
-            lora_rank: 4,
-            ..ClassifyConfig::default()
-        };
+        let classify_config =
+            ClassifyConfig { num_classes: 2, lora_rank: 4, ..ClassifyConfig::default() };
 
         (model_config, classify_config)
     }
@@ -281,13 +272,12 @@ mod tests {
     #[test]
     fn test_coordinator_creation() {
         let (model_config, classify_config) = test_config();
-        let coordinator = DataParallelCoordinator::new(
-            &model_config,
-            classify_config,
-            &[0],
-        );
+        let coordinator = DataParallelCoordinator::new(&model_config, classify_config, &[0]);
         assert!(coordinator.is_ok());
-        assert_eq!(coordinator.as_ref().map(super::DataParallelCoordinator::num_gpus).unwrap_or(0), 1);
+        assert_eq!(
+            coordinator.as_ref().map(super::DataParallelCoordinator::num_gpus).unwrap_or(0),
+            1
+        );
     }
 
     #[test]
@@ -300,12 +290,8 @@ mod tests {
     #[test]
     fn test_multi_gpu_coordinator_accessors() {
         let (model_config, classify_config) = test_config();
-        let mut coordinator = DataParallelCoordinator::new(
-            &model_config,
-            classify_config,
-            &[0],
-        )
-        .expect("creation should succeed");
+        let mut coordinator = DataParallelCoordinator::new(&model_config, classify_config, &[0])
+            .expect("creation should succeed");
 
         // Verify pipeline accessors work
         assert_eq!(coordinator.num_gpus(), 1);
@@ -320,12 +306,8 @@ mod tests {
     #[test]
     fn test_single_gpu_fallback_path() {
         let (model_config, classify_config) = test_config();
-        let coordinator = DataParallelCoordinator::new(
-            &model_config,
-            classify_config,
-            &[0],
-        )
-        .expect("creation should succeed");
+        let coordinator = DataParallelCoordinator::new(&model_config, classify_config, &[0])
+            .expect("creation should succeed");
 
         assert_eq!(coordinator.num_gpus(), 1);
     }
@@ -333,12 +315,8 @@ mod tests {
     #[test]
     fn test_weight_sync_noop_single_gpu() {
         let (model_config, classify_config) = test_config();
-        let mut coordinator = DataParallelCoordinator::new(
-            &model_config,
-            classify_config,
-            &[0],
-        )
-        .expect("creation should succeed");
+        let mut coordinator = DataParallelCoordinator::new(&model_config, classify_config, &[0])
+            .expect("creation should succeed");
 
         coordinator.sync_lora_weights_from_primary();
     }
@@ -351,16 +329,11 @@ mod tests {
     #[test]
     fn falsify_dp_001_weight_sync_makes_replicas_identical() {
         let (model_config, classify_config) = test_config();
-        let mut coordinator = DataParallelCoordinator::new(
-            &model_config,
-            classify_config,
-            &[0, 1],
-        )
-        .expect("creation should succeed");
+        let mut coordinator = DataParallelCoordinator::new(&model_config, classify_config, &[0, 1])
+            .expect("creation should succeed");
 
         // Manually perturb replica 1's weights so they differ
-        let perturbed: Vec<f32> = coordinator.pipelines[1]
-            .lora_layers[0]
+        let perturbed: Vec<f32> = coordinator.pipelines[1].lora_layers[0]
             .lora_a()
             .data()
             .iter()
@@ -386,16 +359,11 @@ mod tests {
     #[test]
     fn falsify_dp_001_weights_diverge_without_sync() {
         let (model_config, classify_config) = test_config();
-        let mut coordinator = DataParallelCoordinator::new(
-            &model_config,
-            classify_config,
-            &[0, 1],
-        )
-        .expect("creation should succeed");
+        let mut coordinator = DataParallelCoordinator::new(&model_config, classify_config, &[0, 1])
+            .expect("creation should succeed");
 
         // Perturb replica 1 (simulating independent optimizer step)
-        let perturbed: Vec<f32> = coordinator.pipelines[1]
-            .lora_layers[0]
+        let perturbed: Vec<f32> = coordinator.pipelines[1].lora_layers[0]
             .lora_a()
             .data()
             .iter()
@@ -417,7 +385,11 @@ mod tests {
 
         for num_workers in [1, 2, 3, 4, 7, 10] {
             let shards = shard_samples(&samples, num_workers);
-            assert_eq!(shards.len(), num_workers, "Wrong number of shards for {num_workers} workers");
+            assert_eq!(
+                shards.len(),
+                num_workers,
+                "Wrong number of shards for {num_workers} workers"
+            );
 
             // All samples covered
             let total: usize = shards.iter().map(|s| s.len()).sum();
@@ -427,7 +399,10 @@ mod tests {
             let mut seen = std::collections::HashSet::new();
             for shard in &shards {
                 for &s in *shard {
-                    assert!(seen.insert(s), "F-DP-002: duplicate sample {s} with {num_workers} workers");
+                    assert!(
+                        seen.insert(s),
+                        "F-DP-002: duplicate sample {s} with {num_workers} workers"
+                    );
                 }
             }
             assert_eq!(seen.len(), 100);
@@ -450,10 +425,7 @@ mod tests {
     // FALSIFY-DP-003: NaN propagation through gradient averaging
     #[test]
     fn falsify_dp_003_nan_gradient_propagates() {
-        let grads = vec![
-            vec![1.0, 2.0, 3.0],
-            vec![f32::NAN, 2.0, 3.0],
-        ];
+        let grads = vec![vec![1.0, 2.0, 3.0], vec![f32::NAN, 2.0, 3.0]];
         let avg = average_gradients(&grads);
         assert!(avg[0].is_nan(), "F-DP-003: NaN MUST propagate through averaging (Jidoka)");
         // Non-NaN elements should still average correctly
@@ -464,10 +436,7 @@ mod tests {
     // FALSIFY-DP-003: Inf propagation
     #[test]
     fn falsify_dp_003_inf_gradient_propagates() {
-        let grads = vec![
-            vec![1.0, 2.0],
-            vec![f32::INFINITY, 2.0],
-        ];
+        let grads = vec![vec![1.0, 2.0], vec![f32::INFINITY, 2.0]];
         let avg = average_gradients(&grads);
         assert!(avg[0].is_infinite(), "F-DP-003: Inf MUST propagate through averaging");
     }
@@ -484,11 +453,7 @@ mod tests {
     // Gradient averaging correctness
     #[test]
     fn test_average_gradients_correct() {
-        let grads = vec![
-            vec![2.0, 4.0, 6.0],
-            vec![4.0, 6.0, 8.0],
-            vec![6.0, 8.0, 10.0],
-        ];
+        let grads = vec![vec![2.0, 4.0, 6.0], vec![4.0, 6.0, 8.0], vec![6.0, 8.0, 10.0]];
         let avg = average_gradients(&grads);
         assert!((avg[0] - 4.0).abs() < 1e-6);
         assert!((avg[1] - 6.0).abs() < 1e-6);
@@ -537,21 +502,12 @@ mod tests {
     #[test]
     fn test_weight_sync_covers_classifier_head() {
         let (model_config, classify_config) = test_config();
-        let mut coordinator = DataParallelCoordinator::new(
-            &model_config,
-            classify_config,
-            &[0, 1],
-        )
-        .expect("creation should succeed");
+        let mut coordinator = DataParallelCoordinator::new(&model_config, classify_config, &[0, 1])
+            .expect("creation should succeed");
 
         // Perturb replica 1's classifier weight
-        let perturbed: Vec<f32> = coordinator.pipelines[1]
-            .classifier
-            .weight
-            .data()
-            .iter()
-            .map(|v| v + 99.0)
-            .collect();
+        let perturbed: Vec<f32> =
+            coordinator.pipelines[1].classifier.weight.data().iter().map(|v| v + 99.0).collect();
         let arr = ndarray::Array1::from(perturbed);
         *coordinator.pipelines[1].classifier.weight.data_mut() = arr;
 
@@ -569,12 +525,9 @@ mod tests {
         let (model_config, classify_config) = test_config();
         for n in [1, 2, 3, 4] {
             let indices: Vec<u32> = (0..n).collect();
-            let coordinator = DataParallelCoordinator::new(
-                &model_config,
-                classify_config.clone(),
-                &indices,
-            )
-            .expect("creation should succeed");
+            let coordinator =
+                DataParallelCoordinator::new(&model_config, classify_config.clone(), &indices)
+                    .expect("creation should succeed");
             assert_eq!(coordinator.num_gpus(), n as usize);
         }
     }
@@ -584,12 +537,8 @@ mod tests {
     #[test]
     fn falsify_dp_001_weight_sync_all_layers_and_classifier() {
         let (model_config, classify_config) = test_config();
-        let mut coordinator = DataParallelCoordinator::new(
-            &model_config,
-            classify_config,
-            &[0, 1],
-        )
-        .expect("creation should succeed");
+        let mut coordinator = DataParallelCoordinator::new(&model_config, classify_config, &[0, 1])
+            .expect("creation should succeed");
 
         // Perturb ALL lora_a/lora_b of replica 1 and classifier
         for lora in &mut coordinator.pipelines[1].lora_layers {
@@ -598,10 +547,9 @@ mod tests {
             let perturbed_b: Vec<f32> = lora.lora_b().data().iter().map(|v| v + 7.0).collect();
             *lora.lora_b_mut().data_mut() = ndarray::Array1::from(perturbed_b);
         }
-        let perturbed_w: Vec<f32> = coordinator.pipelines[1]
-            .classifier.weight.data().iter().map(|v| v + 99.0).collect();
-        *coordinator.pipelines[1].classifier.weight.data_mut() =
-            ndarray::Array1::from(perturbed_w);
+        let perturbed_w: Vec<f32> =
+            coordinator.pipelines[1].classifier.weight.data().iter().map(|v| v + 99.0).collect();
+        *coordinator.pipelines[1].classifier.weight.data_mut() = ndarray::Array1::from(perturbed_w);
 
         // Sync from primary
         coordinator.sync_lora_weights_from_primary();
@@ -649,10 +597,7 @@ mod tests {
 
         // Create samples
         let samples: Vec<SafetySample> = (0..20)
-            .map(|i| SafetySample {
-                input: format!("test_sample_{i}"),
-                label: i % 2,
-            })
+            .map(|i| SafetySample { input: format!("test_sample_{i}"), label: i % 2 })
             .collect();
 
         // ── Single GPU: train locally ──
@@ -674,18 +619,12 @@ mod tests {
         let single_avg_loss = single_loss / samples.len() as f32;
 
         // ── Multi GPU (2 replicas): shard and average ──
-        let mut multi = DataParallelCoordinator::new(
-            &model_config,
-            classify_config,
-            &[0, 1],
-        )
-        .expect("creation should succeed");
+        let mut multi = DataParallelCoordinator::new(&model_config, classify_config, &[0, 1])
+            .expect("creation should succeed");
 
         // Pair token IDs with labels so sharding preserves the mapping
-        let id_label_pairs: Vec<(&Vec<u32>, usize)> = token_ids_batch
-            .iter()
-            .zip(samples.iter().map(|s| s.label))
-            .collect();
+        let id_label_pairs: Vec<(&Vec<u32>, usize)> =
+            token_ids_batch.iter().zip(samples.iter().map(|s| s.label)).collect();
         let shards = shard_samples(&id_label_pairs, 2);
         let mut multi_loss = 0.0f32;
         let mut multi_count = 0usize;
@@ -816,10 +755,7 @@ mod tests {
         assert!(has_non_finite(&[f32::NEG_INFINITY]));
 
         // Averaging NaN+Inf produces NaN
-        let grads = vec![
-            vec![f32::NAN, 1.0],
-            vec![f32::INFINITY, 2.0],
-        ];
+        let grads = vec![vec![f32::NAN, 1.0], vec![f32::INFINITY, 2.0]];
         let avg = average_gradients(&grads);
         assert!(avg[0].is_nan(), "NaN + Inf average should be NaN");
         assert!(has_non_finite(&avg));

--- a/src/finetune/distributed.rs
+++ b/src/finetune/distributed.rs
@@ -107,7 +107,8 @@ impl DistributedConfig {
     }
 
     fn default_node_id() -> String {
-        let hostname = hostname::get().map_or_else(|_| "unknown".to_string(), |h| h.to_string_lossy().to_string());
+        let hostname = hostname::get()
+            .map_or_else(|_| "unknown".to_string(), |h| h.to_string_lossy().to_string());
         let pid = std::process::id();
         format!("{hostname}-{pid}")
     }
@@ -128,22 +129,11 @@ impl Default for DistributedConfig {
 #[derive(Debug, Clone)]
 pub enum WireMessage {
     /// Worker → Coordinator: request to join training
-    JoinRequest {
-        node_id: String,
-        gpu_count: u32,
-        backend: String,
-    },
+    JoinRequest { node_id: String, gpu_count: u32, backend: String },
     /// Coordinator → Worker: join accepted with assigned worker ID
-    JoinAccepted {
-        worker_id: u32,
-        total_workers: u32,
-    },
+    JoinAccepted { worker_id: u32, total_workers: u32 },
     /// Coordinator → Worker: here is your shard for this step
-    ShardAssignment {
-        step: u64,
-        shard_start: usize,
-        shard_end: usize,
-    },
+    ShardAssignment { step: u64, shard_start: usize, shard_end: usize },
     /// Worker → Coordinator: gradient data for this step
     GradientPayload {
         step: u64,
@@ -155,21 +145,13 @@ pub enum WireMessage {
         total: usize,
     },
     /// Coordinator → Worker: averaged gradient for optimizer step
-    AveragedGradient {
-        step: u64,
-        gradients: Vec<f32>,
-        global_loss: f32,
-    },
+    AveragedGradient { step: u64, gradients: Vec<f32>, global_loss: f32 },
     /// Bidirectional: heartbeat ping/pong
-    Heartbeat {
-        node_id: String,
-        timestamp_ms: u64,
-    },
+    Heartbeat { node_id: String, timestamp_ms: u64 },
     /// Coordinator → Worker: training complete, shut down
     Shutdown,
 
     // === v2: Per-block gradient messages for DDP pretraining (tags 0x08-0x0B) ===
-
     /// Worker → Coordinator: gradient data for a single transformer block
     ///
     /// Sent after backward pass for block[block_idx]. Contains 9 gradient
@@ -276,14 +258,32 @@ impl WireMessage {
                 buf.extend_from_slice(&timestamp_ms.to_le_bytes());
             }
             Self::Shutdown => buf.push(0x07),
-            Self::BlockGradientPayload { step, worker_id, block_idx, num_blocks, gradients, component_sizes } =>
-                serialize_block_grad(&mut buf, 0x08, *step, *worker_id, *block_idx, *num_blocks, gradients, component_sizes),
-            Self::AveragedBlockGradient { step, block_idx, gradients, component_sizes } =>
-                serialize_averaged_block(&mut buf, *step, *block_idx, gradients, component_sizes),
-            Self::NonBlockGradientPayload { step, worker_id, component, gradients } =>
-                serialize_non_block_grad(&mut buf, *step, *worker_id, *component, gradients),
-            Self::AveragedNonBlockGradient { step, component, gradients } =>
-                serialize_averaged_non_block(&mut buf, *step, *component, gradients),
+            Self::BlockGradientPayload {
+                step,
+                worker_id,
+                block_idx,
+                num_blocks,
+                gradients,
+                component_sizes,
+            } => serialize_block_grad(
+                &mut buf,
+                0x08,
+                *step,
+                *worker_id,
+                *block_idx,
+                *num_blocks,
+                gradients,
+                component_sizes,
+            ),
+            Self::AveragedBlockGradient { step, block_idx, gradients, component_sizes } => {
+                serialize_averaged_block(&mut buf, *step, *block_idx, gradients, component_sizes)
+            }
+            Self::NonBlockGradientPayload { step, worker_id, component, gradients } => {
+                serialize_non_block_grad(&mut buf, *step, *worker_id, *component, gradients)
+            }
+            Self::AveragedNonBlockGradient { step, component, gradients } => {
+                serialize_averaged_non_block(&mut buf, *step, *component, gradients)
+            }
         }
         buf
     }
@@ -370,9 +370,8 @@ fn decode_averaged_gradient(rest: &[u8]) -> Result<WireMessage, String> {
         return Err("truncated AveragedGradient data".to_string());
     }
     let gradients = read_f32_vec(rest, 16, grad_len);
-    let global_loss = f32::from_le_bytes(
-        rest[16 + grad_bytes..16 + grad_bytes + 4].try_into().expect("4 bytes"),
-    );
+    let global_loss =
+        f32::from_le_bytes(rest[16 + grad_bytes..16 + grad_bytes + 4].try_into().expect("4 bytes"));
     Ok(WireMessage::AveragedGradient { step, gradients, global_loss })
 }
 
@@ -403,10 +402,12 @@ fn decode_block_gradient_payload(rest: &[u8]) -> Result<WireMessage, String> {
     let mut component_sizes = Vec::with_capacity(num_components);
     for i in 0..num_components {
         let start = 24 + i * 4;
-        component_sizes.push(u32::from_le_bytes(rest[start..start + 4].try_into().expect("4 bytes")));
+        component_sizes
+            .push(u32::from_le_bytes(rest[start..start + 4].try_into().expect("4 bytes")));
     }
 
-    let grad_len = u64::from_le_bytes(rest[comp_end..comp_end + 8].try_into().expect("8 bytes")) as usize;
+    let grad_len =
+        u64::from_le_bytes(rest[comp_end..comp_end + 8].try_into().expect("8 bytes")) as usize;
     let grad_start = comp_end + 8;
     if rest.len() < grad_start + grad_len * 4 {
         return Err("truncated BlockGradientPayload gradients".to_string());
@@ -439,22 +440,19 @@ fn decode_averaged_block_gradient(rest: &[u8]) -> Result<WireMessage, String> {
     let mut component_sizes = Vec::with_capacity(num_components);
     for i in 0..num_components {
         let start = 16 + i * 4;
-        component_sizes.push(u32::from_le_bytes(rest[start..start + 4].try_into().expect("4 bytes")));
+        component_sizes
+            .push(u32::from_le_bytes(rest[start..start + 4].try_into().expect("4 bytes")));
     }
 
-    let grad_len = u64::from_le_bytes(rest[comp_end..comp_end + 8].try_into().expect("8 bytes")) as usize;
+    let grad_len =
+        u64::from_le_bytes(rest[comp_end..comp_end + 8].try_into().expect("8 bytes")) as usize;
     let grad_start = comp_end + 8;
     if rest.len() < grad_start + grad_len * 4 {
         return Err("truncated AveragedBlockGradient gradients".to_string());
     }
     let gradients = read_f32_vec(rest, grad_start, grad_len);
 
-    Ok(WireMessage::AveragedBlockGradient {
-        step,
-        block_idx,
-        gradients,
-        component_sizes,
-    })
+    Ok(WireMessage::AveragedBlockGradient { step, block_idx, gradients, component_sizes })
 }
 
 fn decode_non_block_gradient_payload(rest: &[u8]) -> Result<WireMessage, String> {
@@ -471,12 +469,7 @@ fn decode_non_block_gradient_payload(rest: &[u8]) -> Result<WireMessage, String>
     }
     let gradients = read_f32_vec(rest, 21, grad_len);
 
-    Ok(WireMessage::NonBlockGradientPayload {
-        step,
-        worker_id,
-        component,
-        gradients,
-    })
+    Ok(WireMessage::NonBlockGradientPayload { step, worker_id, component, gradients })
 }
 
 fn decode_averaged_non_block_gradient(rest: &[u8]) -> Result<WireMessage, String> {
@@ -492,11 +485,7 @@ fn decode_averaged_non_block_gradient(rest: &[u8]) -> Result<WireMessage, String
     }
     let gradients = read_f32_vec(rest, 17, grad_len);
 
-    Ok(WireMessage::AveragedNonBlockGradient {
-        step,
-        component,
-        gradients,
-    })
+    Ok(WireMessage::AveragedNonBlockGradient { step, component, gradients })
 }
 
 fn read_f32_vec(data: &[u8], offset: usize, count: usize) -> Vec<f32> {
@@ -527,8 +516,14 @@ fn write_component_sizes(buf: &mut Vec<u8>, sizes: &[u32]) {
 
 /// Serialize a BlockGradientPayload (tag 0x08).
 fn serialize_block_grad(
-    buf: &mut Vec<u8>, tag: u8, step: u64, worker_id: u32,
-    block_idx: u32, num_blocks: u32, gradients: &[f32], component_sizes: &[u32],
+    buf: &mut Vec<u8>,
+    tag: u8,
+    step: u64,
+    worker_id: u32,
+    block_idx: u32,
+    num_blocks: u32,
+    gradients: &[f32],
+    component_sizes: &[u32],
 ) {
     buf.push(tag);
     buf.extend_from_slice(&step.to_le_bytes());
@@ -541,7 +536,11 @@ fn serialize_block_grad(
 
 /// Serialize an AveragedBlockGradient (tag 0x09).
 fn serialize_averaged_block(
-    buf: &mut Vec<u8>, step: u64, block_idx: u32, gradients: &[f32], component_sizes: &[u32],
+    buf: &mut Vec<u8>,
+    step: u64,
+    block_idx: u32,
+    gradients: &[f32],
+    component_sizes: &[u32],
 ) {
     buf.push(0x09);
     buf.extend_from_slice(&step.to_le_bytes());
@@ -551,7 +550,13 @@ fn serialize_averaged_block(
 }
 
 /// Serialize a NonBlockGradientPayload (tag 0x0A).
-fn serialize_non_block_grad(buf: &mut Vec<u8>, step: u64, worker_id: u32, component: u8, gradients: &[f32]) {
+fn serialize_non_block_grad(
+    buf: &mut Vec<u8>,
+    step: u64,
+    worker_id: u32,
+    component: u8,
+    gradients: &[f32],
+) {
     buf.push(0x0A);
     buf.extend_from_slice(&step.to_le_bytes());
     buf.extend_from_slice(&worker_id.to_le_bytes());
@@ -581,8 +586,8 @@ fn read_string(data: &[u8]) -> Result<(String, &[u8]), String> {
     if data.len() < 4 + len {
         return Err("truncated string data".to_string());
     }
-    let s = String::from_utf8(data[4..4 + len].to_vec())
-        .map_err(|e| format!("invalid utf8: {e}"))?;
+    let s =
+        String::from_utf8(data[4..4 + len].to_vec()).map_err(|e| format!("invalid utf8: {e}"))?;
     Ok((s, &data[4 + len..]))
 }
 
@@ -605,10 +610,7 @@ mod tests {
         let config = DistributedConfig::worker("192.168.50.100:9000".parse().expect("valid"));
         assert!(!config.is_coordinator());
         assert_eq!(config.role, NodeRole::Worker);
-        assert_eq!(
-            config.coordinator_addr,
-            Some("192.168.50.100:9000".parse().expect("valid"))
-        );
+        assert_eq!(config.coordinator_addr, Some("192.168.50.100:9000".parse().expect("valid")));
     }
 
     #[test]
@@ -644,11 +646,7 @@ mod tests {
         let payload = &bytes[4..];
         let decoded = WireMessage::from_payload(payload).expect("valid");
         match decoded {
-            WireMessage::JoinRequest {
-                node_id,
-                gpu_count,
-                backend,
-            } => {
+            WireMessage::JoinRequest { node_id, gpu_count, backend } => {
                 assert_eq!(node_id, "intel-1234");
                 assert_eq!(gpu_count, 2);
                 assert_eq!(backend, "wgpu");
@@ -659,17 +657,11 @@ mod tests {
 
     #[test]
     fn test_wire_join_accepted_roundtrip() {
-        let msg = WireMessage::JoinAccepted {
-            worker_id: 1,
-            total_workers: 3,
-        };
+        let msg = WireMessage::JoinAccepted { worker_id: 1, total_workers: 3 };
         let bytes = msg.to_bytes();
         let decoded = WireMessage::from_payload(&bytes[4..]).expect("valid");
         match decoded {
-            WireMessage::JoinAccepted {
-                worker_id,
-                total_workers,
-            } => {
+            WireMessage::JoinAccepted { worker_id, total_workers } => {
                 assert_eq!(worker_id, 1);
                 assert_eq!(total_workers, 3);
             }
@@ -679,19 +671,11 @@ mod tests {
 
     #[test]
     fn test_wire_shard_assignment_roundtrip() {
-        let msg = WireMessage::ShardAssignment {
-            step: 42,
-            shard_start: 100,
-            shard_end: 200,
-        };
+        let msg = WireMessage::ShardAssignment { step: 42, shard_start: 100, shard_end: 200 };
         let bytes = msg.to_bytes();
         let decoded = WireMessage::from_payload(&bytes[4..]).expect("valid");
         match decoded {
-            WireMessage::ShardAssignment {
-                step,
-                shard_start,
-                shard_end,
-            } => {
+            WireMessage::ShardAssignment { step, shard_start, shard_end } => {
                 assert_eq!(step, 42);
                 assert_eq!(shard_start, 100);
                 assert_eq!(shard_end, 200);
@@ -714,14 +698,7 @@ mod tests {
         let bytes = msg.to_bytes();
         let decoded = WireMessage::from_payload(&bytes[4..]).expect("valid");
         match decoded {
-            WireMessage::GradientPayload {
-                step,
-                worker_id,
-                gradients,
-                loss,
-                correct,
-                total,
-            } => {
+            WireMessage::GradientPayload { step, worker_id, gradients, loss, correct, total } => {
                 assert_eq!(step, 10);
                 assert_eq!(worker_id, 2);
                 assert_eq!(gradients, grads);
@@ -736,19 +713,12 @@ mod tests {
     #[test]
     fn test_wire_averaged_gradient_roundtrip() {
         let grads = vec![0.5f32, 1.0, 1.5];
-        let msg = WireMessage::AveragedGradient {
-            step: 5,
-            gradients: grads.clone(),
-            global_loss: 0.789,
-        };
+        let msg =
+            WireMessage::AveragedGradient { step: 5, gradients: grads.clone(), global_loss: 0.789 };
         let bytes = msg.to_bytes();
         let decoded = WireMessage::from_payload(&bytes[4..]).expect("valid");
         match decoded {
-            WireMessage::AveragedGradient {
-                step,
-                gradients,
-                global_loss,
-            } => {
+            WireMessage::AveragedGradient { step, gradients, global_loss } => {
                 assert_eq!(step, 5);
                 assert_eq!(gradients, grads);
                 assert!((global_loss - 0.789).abs() < 1e-6);
@@ -766,10 +736,7 @@ mod tests {
         let bytes = msg.to_bytes();
         let decoded = WireMessage::from_payload(&bytes[4..]).expect("valid");
         match decoded {
-            WireMessage::Heartbeat {
-                node_id,
-                timestamp_ms,
-            } => {
+            WireMessage::Heartbeat { node_id, timestamp_ms } => {
                 assert_eq!(node_id, "lambda-5678");
                 assert_eq!(timestamp_ms, 1_709_000_000_000);
             }
@@ -875,12 +842,7 @@ mod tests {
         let bytes = msg.to_bytes();
         let decoded = WireMessage::from_payload(&bytes[4..]).expect("valid");
         match decoded {
-            WireMessage::NonBlockGradientPayload {
-                step,
-                worker_id,
-                component,
-                gradients,
-            } => {
+            WireMessage::NonBlockGradientPayload { step, worker_id, component, gradients } => {
                 assert_eq!(step, 10);
                 assert_eq!(worker_id, 0);
                 assert_eq!(component, 2);
@@ -901,11 +863,7 @@ mod tests {
         let bytes = msg.to_bytes();
         let decoded = WireMessage::from_payload(&bytes[4..]).expect("valid");
         match decoded {
-            WireMessage::AveragedNonBlockGradient {
-                step,
-                component,
-                gradients,
-            } => {
+            WireMessage::AveragedNonBlockGradient { step, component, gradients } => {
                 assert_eq!(step, 50);
                 assert_eq!(component, 0);
                 assert_eq!(gradients, grads);
@@ -966,9 +924,7 @@ mod tests {
 
         let decoded = WireMessage::from_payload(&bytes[4..]).expect("valid");
         match decoded {
-            WireMessage::GradientPayload {
-                gradients, loss, ..
-            } => {
+            WireMessage::GradientPayload { gradients, loss, .. } => {
                 assert_eq!(gradients.len(), grad_len);
                 assert!((loss - 0.123).abs() < 1e-6);
             }

--- a/src/finetune/gradient_server.rs
+++ b/src/finetune/gradient_server.rs
@@ -93,12 +93,7 @@ impl GradientServer {
             "[coordinator] Listening on {} (expecting {} workers)",
             config.bind_addr, config.expect_workers
         );
-        Ok(Self {
-            config,
-            listener,
-            workers: Vec::new(),
-            total_samples: 0,
-        })
+        Ok(Self { config, listener, workers: Vec::new(), total_samples: 0 })
     }
 
     /// Wait for all expected workers to connect.
@@ -112,30 +107,22 @@ impl GradientServer {
         eprintln!("[coordinator] Waiting for {expected} workers to connect...");
 
         while self.workers.len() < expected {
-            let (stream, addr) = self
-                .listener
-                .accept()
-                .map_err(|e| format!("accept failed: {e}"))?;
+            let (stream, addr) =
+                self.listener.accept().map_err(|e| format!("accept failed: {e}"))?;
             eprintln!("[coordinator] Connection from {addr}");
 
             // Read JoinRequest
             let msg = read_wire_message(&stream)?;
             match msg {
-                WireMessage::JoinRequest {
-                    node_id,
-                    gpu_count,
-                    backend,
-                } => {
+                WireMessage::JoinRequest { node_id, gpu_count, backend } => {
                     let worker_id = self.workers.len() as u32;
                     eprintln!(
                         "[coordinator] Worker {worker_id} joined: {node_id} ({gpu_count} GPUs, {backend})"
                     );
 
                     // Send JoinAccepted
-                    let response = WireMessage::JoinAccepted {
-                        worker_id,
-                        total_workers: expected as u32,
-                    };
+                    let response =
+                        WireMessage::JoinAccepted { worker_id, total_workers: expected as u32 };
                     send_wire_message(&stream, &response)?;
 
                     self.workers.push(WorkerConnection {
@@ -171,16 +158,8 @@ impl GradientServer {
 
         for (i, worker) in self.workers.iter().enumerate() {
             let start = i * shard_size;
-            let end = if i == n - 1 {
-                self.total_samples
-            } else {
-                start + shard_size
-            };
-            let msg = WireMessage::ShardAssignment {
-                step,
-                shard_start: start,
-                shard_end: end,
-            };
+            let end = if i == n - 1 { self.total_samples } else { start + shard_size };
+            let msg = WireMessage::ShardAssignment { step, shard_start: start, shard_end: end };
             send_wire_message(&worker.stream, &msg)?;
         }
         Ok(())
@@ -214,9 +193,7 @@ impl GradientServer {
                     ..
                 } => {
                     if recv_step != step {
-                        return Err(format!(
-                            "step mismatch: expected {step}, got {recv_step}"
-                        ));
+                        return Err(format!("step mismatch: expected {step}, got {recv_step}"));
                     }
 
                     // Jidoka: halt on NaN/Inf (F-DP-003)
@@ -243,11 +220,7 @@ impl GradientServer {
 
         // AllReduce: average gradients (F-DP-001)
         let avg_gradients = average_gradients(&all_grads);
-        let global_loss = if total_samples > 0 {
-            total_loss / total_samples as f32
-        } else {
-            0.0
-        };
+        let global_loss = if total_samples > 0 { total_loss / total_samples as f32 } else { 0.0 };
 
         let allreduce_ms = start.elapsed().as_secs_f64() * 1000.0;
 
@@ -327,9 +300,7 @@ impl GradientServer {
                     ..
                 } => {
                     if recv_step != step {
-                        return Err(format!(
-                            "step mismatch: expected {step}, got {recv_step}"
-                        ));
+                        return Err(format!("step mismatch: expected {step}, got {recv_step}"));
                     }
                     if recv_block_idx != block_idx {
                         return Err(format!(
@@ -359,12 +330,7 @@ impl GradientServer {
         let avg_gradients = average_gradients(&all_grads);
         let allreduce_ms = start.elapsed().as_secs_f64() * 1000.0;
 
-        Ok(BlockAllReduceResult {
-            block_idx,
-            avg_gradients,
-            component_sizes,
-            allreduce_ms,
-        })
+        Ok(BlockAllReduceResult { block_idx, avg_gradients, component_sizes, allreduce_ms })
     }
 
     /// Broadcast averaged block gradient to all workers.
@@ -413,9 +379,7 @@ impl GradientServer {
                     ..
                 } => {
                     if recv_step != step {
-                        return Err(format!(
-                            "step mismatch: expected {step}, got {recv_step}"
-                        ));
+                        return Err(format!("step mismatch: expected {step}, got {recv_step}"));
                     }
                     if component != expected_component {
                         return Err(format!(
@@ -442,11 +406,7 @@ impl GradientServer {
         let avg_gradients = average_gradients(&all_grads);
         let allreduce_ms = start.elapsed().as_secs_f64() * 1000.0;
 
-        Ok(NonBlockAllReduceResult {
-            component: expected_component,
-            avg_gradients,
-            allreduce_ms,
-        })
+        Ok(NonBlockAllReduceResult { component: expected_component, avg_gradients, allreduce_ms })
     }
 
     /// Broadcast averaged non-block gradient to all workers.
@@ -472,9 +432,7 @@ impl GradientServer {
 /// Read a length-prefixed wire message from a TCP stream.
 pub(crate) fn read_wire_message(stream: &TcpStream) -> Result<WireMessage, String> {
     let mut len_buf = [0u8; 4];
-    (&*stream)
-        .read_exact(&mut len_buf)
-        .map_err(|e| format!("read length failed: {e}"))?;
+    (&*stream).read_exact(&mut len_buf).map_err(|e| format!("read length failed: {e}"))?;
     let len = u32::from_be_bytes(len_buf) as usize;
 
     if len > 100_000_000 {
@@ -482,9 +440,7 @@ pub(crate) fn read_wire_message(stream: &TcpStream) -> Result<WireMessage, Strin
     }
 
     let mut payload = vec![0u8; len];
-    (&*stream)
-        .read_exact(&mut payload)
-        .map_err(|e| format!("read payload failed: {e}"))?;
+    (&*stream).read_exact(&mut payload).map_err(|e| format!("read payload failed: {e}"))?;
 
     WireMessage::from_payload(&payload)
 }
@@ -492,12 +448,8 @@ pub(crate) fn read_wire_message(stream: &TcpStream) -> Result<WireMessage, Strin
 /// Send a wire message to a TCP stream.
 pub(crate) fn send_wire_message(stream: &TcpStream, msg: &WireMessage) -> Result<(), String> {
     let bytes = msg.to_bytes();
-    (&*stream)
-        .write_all(&bytes)
-        .map_err(|e| format!("send failed: {e}"))?;
-    (&*stream)
-        .flush()
-        .map_err(|e| format!("flush failed: {e}"))?;
+    (&*stream).write_all(&bytes).map_err(|e| format!("send failed: {e}"))?;
+    (&*stream).flush().map_err(|e| format!("flush failed: {e}"))?;
     Ok(())
 }
 
@@ -552,10 +504,7 @@ mod tests {
             // Read JoinAccepted
             let response = read_wire_message(&stream).expect("valid");
             match response {
-                WireMessage::JoinAccepted {
-                    worker_id,
-                    total_workers,
-                } => {
+                WireMessage::JoinAccepted { worker_id, total_workers } => {
                     assert_eq!(worker_id, 0);
                     assert_eq!(total_workers, 1);
                 }
@@ -592,11 +541,9 @@ mod tests {
                     // Read shard assignment
                     let shard_msg = read_wire_message(&stream).expect("valid");
                     let (shard_start, shard_end) = match shard_msg {
-                        WireMessage::ShardAssignment {
-                            shard_start,
-                            shard_end,
-                            ..
-                        } => (shard_start, shard_end),
+                        WireMessage::ShardAssignment { shard_start, shard_end, .. } => {
+                            (shard_start, shard_end)
+                        }
                         other => panic!("expected ShardAssignment, got {other:?}"),
                     };
 

--- a/src/finetune/instruct_corpus.rs
+++ b/src/finetune/instruct_corpus.rs
@@ -90,12 +90,8 @@ pub struct InstructCorpusStats {
 /// # Errors
 /// Returns error if file cannot be read or contains invalid samples.
 pub fn load_instruct_corpus(path: &Path) -> crate::Result<Vec<InstructSample>> {
-    let content = std::fs::read_to_string(path).map_err(|e| {
-        crate::Error::Io(format!(
-            "Corpus file not found: {}: {e}",
-            path.display()
-        ))
-    })?;
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| crate::Error::Io(format!("Corpus file not found: {}: {e}", path.display())))?;
 
     let mut samples = Vec::new();
     for (line_num, line) in content.lines().enumerate() {
@@ -104,10 +100,7 @@ pub fn load_instruct_corpus(path: &Path) -> crate::Result<Vec<InstructSample>> {
             continue;
         }
         let sample: InstructSample = serde_json::from_str(line).map_err(|e| {
-            crate::Error::ConfigError(format!(
-                "Invalid JSONL at line {}: {e}",
-                line_num + 1
-            ))
+            crate::Error::ConfigError(format!("Invalid JSONL at line {}: {e}", line_num + 1))
         })?;
 
         // F-INST-001: non-empty validation
@@ -146,10 +139,8 @@ pub fn instruct_corpus_stats(samples: &[InstructSample]) -> InstructCorpusStats 
     let total_resp_len: usize = samples.iter().map(|s| s.response.len()).sum();
     let with_system = samples.iter().filter(|s| s.system.is_some()).count();
 
-    let mut sources: Vec<String> = samples
-        .iter()
-        .filter_map(|s| s.metadata.as_ref()?.source.clone())
-        .collect();
+    let mut sources: Vec<String> =
+        samples.iter().filter_map(|s| s.metadata.as_ref()?.source.clone()).collect();
     sources.sort();
     sources.dedup();
 
@@ -176,11 +167,8 @@ mod tests {
             r#"{{"instruction": "Write hello world", "response": "print('hello world')"}}"#
         )
         .expect("valid");
-        writeln!(
-            f,
-            r#"{{"instruction": "Sort a list", "response": "sorted(lst)"}}"#
-        )
-        .expect("valid");
+        writeln!(f, r#"{{"instruction": "Sort a list", "response": "sorted(lst)"}}"#)
+            .expect("valid");
 
         let samples = load_instruct_corpus(f.path()).expect("valid");
         assert_eq!(samples.len(), 2);
@@ -191,11 +179,7 @@ mod tests {
     #[test]
     fn test_empty_instruction_rejected() {
         let mut f = NamedTempFile::new().expect("valid");
-        writeln!(
-            f,
-            r#"{{"instruction": "", "response": "some code"}}"#
-        )
-        .expect("valid");
+        writeln!(f, r#"{{"instruction": "", "response": "some code"}}"#).expect("valid");
 
         let result = load_instruct_corpus(f.path());
         assert!(result.is_err());
@@ -205,11 +189,7 @@ mod tests {
     #[test]
     fn test_empty_response_rejected() {
         let mut f = NamedTempFile::new().expect("valid");
-        writeln!(
-            f,
-            r#"{{"instruction": "Do something", "response": "  "}}"#
-        )
-        .expect("valid");
+        writeln!(f, r#"{{"instruction": "Do something", "response": "  "}}"#).expect("valid");
 
         let result = load_instruct_corpus(f.path());
         assert!(result.is_err());
@@ -276,17 +256,9 @@ mod tests {
     #[test]
     fn test_skip_empty_lines() {
         let mut f = NamedTempFile::new().expect("valid");
-        writeln!(
-            f,
-            r#"{{"instruction": "a", "response": "b"}}"#
-        )
-        .expect("valid");
+        writeln!(f, r#"{{"instruction": "a", "response": "b"}}"#).expect("valid");
         writeln!(f).expect("valid"); // empty line
-        writeln!(
-            f,
-            r#"{{"instruction": "c", "response": "d"}}"#
-        )
-        .expect("valid");
+        writeln!(f, r#"{{"instruction": "c", "response": "d"}}"#).expect("valid");
 
         let samples = load_instruct_corpus(f.path()).expect("valid");
         assert_eq!(samples.len(), 2);

--- a/src/finetune/instruct_pipeline.rs
+++ b/src/finetune/instruct_pipeline.rs
@@ -24,19 +24,23 @@ use crate::Tensor;
 use std::path::{Path, PathBuf};
 
 #[cfg(feature = "cuda")]
-use crate::autograd::cuda_forward::{gemm_forward, pre_warm_forward_kernels, pre_warm_lora_backward_kernels};
-#[cfg(feature = "cuda")]
 use crate::autograd::cuda_backward::pre_warm_lora_backward_kernels as pre_warm_backward_cache_kernels;
+#[cfg(feature = "cuda")]
+use crate::autograd::cuda_forward::{
+    gemm_forward, pre_warm_forward_kernels, pre_warm_lora_backward_kernels,
+};
 #[cfg(feature = "cuda")]
 use crate::autograd::cuda_optim::{fused_causal_cross_entropy_cuda, pre_warm_lora_adamw_kernels};
 #[cfg(feature = "cuda")]
 use crate::autograd::cuda_training::{cuda_training_available, CudaTrainer};
 #[cfg(feature = "cuda")]
-use crate::transformer::{CudaBlock, CudaBlockScratch, CudaLoraGradWorkspace, CudaTransformerBlock, GpuLoraOptimizerState};
+use crate::gpu::guard::VramGuard;
+#[cfg(feature = "cuda")]
+use crate::transformer::{
+    CudaBlock, CudaBlockScratch, CudaLoraGradWorkspace, CudaTransformerBlock, GpuLoraOptimizerState,
+};
 #[cfg(feature = "cuda")]
 use std::sync::Arc;
-#[cfg(feature = "cuda")]
-use crate::gpu::guard::VramGuard;
 #[cfg(feature = "cuda")]
 use trueno_gpu::driver::GpuBuffer;
 
@@ -197,8 +201,7 @@ impl InstructPipeline {
     /// Create a new pipeline with random weights.
     pub fn new(model_config: &TransformerConfig, instruct_config: InstructConfig) -> Self {
         let model = Transformer::new(model_config);
-        let mut lora_layers =
-            Self::build_lora_layers(&model, model_config, &instruct_config);
+        let mut lora_layers = Self::build_lora_layers(&model, model_config, &instruct_config);
 
         for lora in &mut lora_layers {
             for param in lora.trainable_params() {
@@ -256,8 +259,7 @@ impl InstructPipeline {
         instruct_config: InstructConfig,
     ) -> crate::Result<Self> {
         let model = Transformer::from_safetensors(model_dir, model_config)?;
-        let mut lora_layers =
-            Self::build_lora_layers(&model, model_config, &instruct_config);
+        let mut lora_layers = Self::build_lora_layers(&model, model_config, &instruct_config);
 
         for lora in &mut lora_layers {
             for param in lora.trainable_params() {
@@ -334,8 +336,7 @@ impl InstructPipeline {
         instruct_config: InstructConfig,
     ) -> crate::Result<Self> {
         let model = Transformer::from_apr(apr_path, model_config)?;
-        let mut lora_layers =
-            Self::build_lora_layers(&model, model_config, &instruct_config);
+        let mut lora_layers = Self::build_lora_layers(&model, model_config, &instruct_config);
 
         for lora in &mut lora_layers {
             for param in lora.trainable_params() {
@@ -348,13 +349,11 @@ impl InstructPipeline {
         // Sibling tokenizer: {stem}.tokenizer.json next to the .apr file
         // CONTRACT: Training requires a BPE tokenizer — byte-fallback is not acceptable.
         let tokenizer = {
-            let sibling = apr_path
-                .file_stem()
-                .and_then(|stem| {
-                    apr_path
-                        .parent()
-                        .map(|p| p.join(format!("{}.tokenizer.json", stem.to_str().unwrap_or(""))))
-                });
+            let sibling = apr_path.file_stem().and_then(|stem| {
+                apr_path
+                    .parent()
+                    .map(|p| p.join(format!("{}.tokenizer.json", stem.to_str().unwrap_or(""))))
+            });
 
             match sibling {
                 Some(ref path) if path.exists() => {
@@ -499,27 +498,14 @@ impl InstructPipeline {
     ///
     /// When CUDA NF4 blocks are available, dispatches to GPU forward pass
     /// with CPU loss computation and GPU backward/optimizer.
-    pub fn train_step(
-        &mut self,
-        prompt_ids: &[u32],
-        response_ids: &[u32],
-    ) -> InstructStepResult {
-        let full_ids: Vec<u32> = prompt_ids
-            .iter()
-            .chain(response_ids.iter())
-            .copied()
-            .collect();
+    pub fn train_step(&mut self, prompt_ids: &[u32], response_ids: &[u32]) -> InstructStepResult {
+        let full_ids: Vec<u32> = prompt_ids.iter().chain(response_ids.iter()).copied().collect();
 
         let prompt_len = prompt_ids.len();
         let response_len = response_ids.len();
 
-
         if response_len == 0 || full_ids.len() < 2 {
-            return InstructStepResult {
-                loss: 0.0,
-                num_response_tokens: 0,
-                perplexity: 1.0,
-            };
+            return InstructStepResult { loss: 0.0, num_response_tokens: 0, perplexity: 1.0 };
         }
 
         let full_ids = if full_ids.len() > self.config.max_seq_len {
@@ -551,11 +537,7 @@ impl InstructPipeline {
 
         // 2. Forward pass → logits [seq_len, vocab_size]
         let logits = self.model.forward(&full_ids);
-        let logits_data = logits
-            .data()
-            .as_slice()
-            .expect("contiguous logits")
-            .to_vec();
+        let logits_data = logits.data().as_slice().expect("contiguous logits").to_vec();
 
         // 3. Causal LM loss on response tokens only
         let loss_start = prompt_len.saturating_sub(1);
@@ -563,11 +545,7 @@ impl InstructPipeline {
         let num_loss_tokens = loss_end.saturating_sub(loss_start);
 
         if num_loss_tokens == 0 {
-            return InstructStepResult {
-                loss: 0.0,
-                num_response_tokens: 0,
-                perplexity: 1.0,
-            };
+            return InstructStepResult { loss: 0.0, num_response_tokens: 0, perplexity: 1.0 };
         }
 
         let (avg_loss, grad_logits) =
@@ -618,11 +596,7 @@ impl InstructPipeline {
         let num_loss_tokens = loss_end.saturating_sub(loss_start);
 
         if num_loss_tokens == 0 {
-            return InstructStepResult {
-                loss: 0.0,
-                num_response_tokens: 0,
-                perplexity: 1.0,
-            };
+            return InstructStepResult { loss: 0.0, num_response_tokens: 0, perplexity: 1.0 };
         }
 
         // 1. GPU forward → logits stay GPU-resident in training.logits_buf (KAIZEN-064)
@@ -630,7 +604,14 @@ impl InstructPipeline {
         if !self.forward_logits_gpu_resident(full_ids) {
             // Fallback: GPU forward failed, use CPU path with D2H
             eprintln!("[CUDA] GPU forward failed, falling back to CPU for this step");
-            return self.cuda_train_step_cpu_loss(full_ids, loss_start, loss_end, num_loss_tokens, seq_len, vocab_size);
+            return self.cuda_train_step_cpu_loss(
+                full_ids,
+                loss_start,
+                loss_end,
+                num_loss_tokens,
+                seq_len,
+                vocab_size,
+            );
         }
 
         // 2. Fused GPU causal cross-entropy loss + softmax backward (KAIZEN-064)
@@ -638,9 +619,9 @@ impl InstructPipeline {
         //    - CPU softmax computation
         //    - ~296MB grad_logits H2D upload
         //    Prepare shifted targets: position pos predicts full_ids[pos + 1]
-        let targets: Vec<u32> = (0..seq_len).map(|pos| {
-            if pos + 1 < full_ids.len() { full_ids[pos + 1] } else { 0 }
-        }).collect();
+        let targets: Vec<u32> = (0..seq_len)
+            .map(|pos| if pos + 1 < full_ids.len() { full_ids[pos + 1] } else { 0 })
+            .collect();
 
         let scale = 1.0 / num_loss_tokens as f32;
 
@@ -657,7 +638,8 @@ impl InstructPipeline {
                 loss_end as u32,
                 scale,
                 stream,
-            ).ok()
+            )
+            .ok()
         })();
 
         let avg_loss = match avg_loss {
@@ -672,7 +654,14 @@ impl InstructPipeline {
             }
             None => {
                 eprintln!("[CUDA] fused causal cross-entropy failed — falling back to CPU");
-                return self.cuda_train_step_cpu_loss(full_ids, loss_start, loss_end, num_loss_tokens, seq_len, vocab_size);
+                return self.cuda_train_step_cpu_loss(
+                    full_ids,
+                    loss_start,
+                    loss_end,
+                    num_loss_tokens,
+                    seq_len,
+                    vocab_size,
+                );
             }
         };
 
@@ -695,9 +684,11 @@ impl InstructPipeline {
                 vocab_size as u32,
                 hidden_size as u32,
                 stream,
-            ).map_err(|e| {
+            )
+            .map_err(|e| {
                 eprintln!("[CUDA] lm_head backward GEMM failed: {e}");
-            }).ok()?;
+            })
+            .ok()?;
             // KAIZEN-065: No stream.synchronize() needed — GEMM and rms_norm_backward
             // are on the same CUDA stream, so ordering is guaranteed.
             // No trainer.download() needed — grad_hidden_buf is read directly by
@@ -765,9 +756,13 @@ impl InstructPipeline {
             let trainer = self.cuda_trainer.as_ref()?;
             let stream = trainer.stream();
             let training = self.gpu_training.as_mut()?;
-            training.logits_buf.copy_from_host_at(&grad_logits, 0).map_err(|e| {
-                eprintln!("[CUDA] lm_head backward: grad_logits upload failed: {e}");
-            }).ok()?;
+            training
+                .logits_buf
+                .copy_from_host_at(&grad_logits, 0)
+                .map_err(|e| {
+                    eprintln!("[CUDA] lm_head backward: grad_logits upload failed: {e}");
+                })
+                .ok()?;
             // KAIZEN-068: embed_original is GPU-resident — no per-step H2D upload.
             gemm_forward(
                 &training.logits_buf,
@@ -777,9 +772,11 @@ impl InstructPipeline {
                 vocab_size as u32,
                 hidden_size as u32,
                 stream,
-            ).map_err(|e| {
+            )
+            .map_err(|e| {
                 eprintln!("[CUDA] lm_head backward GEMM failed: {e}");
-            }).ok()?;
+            })
+            .ok()?;
             stream.synchronize().ok()?;
             let full_grad = trainer.download(&training.grad_hidden_buf).ok()?;
             Some(full_grad[..seq_len * hidden_size].to_vec())
@@ -816,14 +813,9 @@ impl InstructPipeline {
         let mut total_loss = 0.0f32;
         let mut total_response_tokens = 0usize;
 
-        for (prompt_ids, response_ids) in
-            prompt_ids_batch.iter().zip(response_ids_batch.iter())
-        {
-            let full_ids: Vec<u32> = prompt_ids
-                .iter()
-                .chain(response_ids.iter())
-                .copied()
-                .collect();
+        for (prompt_ids, response_ids) in prompt_ids_batch.iter().zip(response_ids_batch.iter()) {
+            let full_ids: Vec<u32> =
+                prompt_ids.iter().chain(response_ids.iter()).copied().collect();
 
             let prompt_len = prompt_ids.len();
             if response_ids.is_empty() || full_ids.len() < 2 {
@@ -840,11 +832,7 @@ impl InstructPipeline {
             let prompt_len = prompt_len.min(seq_len);
 
             let logits = self.model.forward(&full_ids);
-            let logits_data = logits
-                .data()
-                .as_slice()
-                .expect("contiguous logits")
-                .to_vec();
+            let logits_data = logits.data().as_slice().expect("contiguous logits").to_vec();
 
             let loss_start = prompt_len.saturating_sub(1);
             let loss_end = seq_len - 1;
@@ -862,11 +850,8 @@ impl InstructPipeline {
             total_response_tokens += num_loss_tokens;
         }
 
-        let avg_loss = if total_response_tokens > 0 {
-            total_loss / total_response_tokens as f32
-        } else {
-            0.0
-        };
+        let avg_loss =
+            if total_response_tokens > 0 { total_loss / total_response_tokens as f32 } else { 0.0 };
 
         InstructBatchResult {
             avg_loss,
@@ -925,11 +910,7 @@ impl InstructPipeline {
             grad_row[target] -= inv_n;
         }
 
-        let avg_loss = if num_loss_tokens > 0 {
-            total_loss / num_loss_tokens as f32
-        } else {
-            0.0
-        };
+        let avg_loss = if num_loss_tokens > 0 { total_loss / num_loss_tokens as f32 } else { 0.0 };
 
         (avg_loss, grad_logits)
     }
@@ -938,7 +919,9 @@ impl InstructPipeline {
     #[must_use]
     pub fn num_trainable_parameters(&self) -> usize {
         // LoRA layers store weight + lora_a + lora_b; we count lora_a + lora_b
-        self.lora_layers.len() * 2 * self.config.lora_rank
+        self.lora_layers.len()
+            * 2
+            * self.config.lora_rank
             * (self.lora_layers.first().map_or(0, |_| {
                 // Approximate: each LoRA pair has rank * (rows + cols) params
                 // This is a rough estimate since layers may differ in size
@@ -991,14 +974,12 @@ impl InstructPipeline {
                 let b_v_unscaled: Vec<f32> = b_v.iter().map(|&v| v * inv_scale).collect();
 
                 if q_lora_idx < self.lora_layers.len() {
-                    *self.lora_layers[q_lora_idx].lora_a_mut() =
-                        crate::Tensor::from_vec(a_q, true);
+                    *self.lora_layers[q_lora_idx].lora_a_mut() = crate::Tensor::from_vec(a_q, true);
                     *self.lora_layers[q_lora_idx].lora_b_mut() =
                         crate::Tensor::from_vec(b_q_unscaled, true);
                 }
                 if v_lora_idx < self.lora_layers.len() {
-                    *self.lora_layers[v_lora_idx].lora_a_mut() =
-                        crate::Tensor::from_vec(a_v, true);
+                    *self.lora_layers[v_lora_idx].lora_a_mut() = crate::Tensor::from_vec(a_v, true);
                     *self.lora_layers[v_lora_idx].lora_b_mut() =
                         crate::Tensor::from_vec(b_v_unscaled, true);
                 }
@@ -1018,11 +999,7 @@ impl InstructPipeline {
     fn init_cuda(&mut self, model_config: &TransformerConfig) {
         // GPU-SHARE-002: Acquire VRAM reservation before allocating
         let budget_mb = Self::estimate_vram_mb(model_config, &self.config);
-        let task_label = if self.config.quantize_nf4 {
-            "instruct-qlora"
-        } else {
-            "instruct-lora"
-        };
+        let task_label = if self.config.quantize_nf4 { "instruct-qlora" } else { "instruct-lora" };
         match VramGuard::acquire(budget_mb, task_label) {
             Ok(guard) => {
                 eprintln!(
@@ -1084,13 +1061,13 @@ impl InstructPipeline {
     fn estimate_vram_mb(model_config: &TransformerConfig, config: &InstructConfig) -> usize {
         if config.quantize_nf4 {
             // NF4 QLoRA: weights at 4-bit (~0.5 bytes/param) + FP32 scratch + overhead
-            let weight_elements = model_config.per_layer_weight_elements()
-                * model_config.num_hidden_layers;
+            let weight_elements =
+                model_config.per_layer_weight_elements() * model_config.num_hidden_layers;
             // NF4 weights: 0.5 bytes/param, LoRA adapters in FP16: ~2% of weights
             let weight_mb = weight_elements / (2 * 1024 * 1024);
             // Scratch buffers scale with seq_len * hidden_size
-            let scratch_mb = (config.max_seq_len * model_config.hidden_size * 4 * 10)
-                / (1024 * 1024);
+            let scratch_mb =
+                (config.max_seq_len * model_config.hidden_size * 4 * 10) / (1024 * 1024);
             // CUDA context + kernel cache + misc overhead
             let overhead_mb = 512;
             weight_mb + scratch_mb + overhead_mb
@@ -1149,7 +1126,9 @@ impl InstructPipeline {
 
         let quantize_nf4 = config.quantize_nf4;
         if quantize_nf4 {
-            eprintln!("[CUDA] NF4 quantization enabled — frozen weights will be 4-bit (~8x compression)");
+            eprintln!(
+                "[CUDA] NF4 quantization enabled — frozen weights will be 4-bit (~8x compression)"
+            );
         }
 
         // C-PREWARM-001: Pre-warm ALL training kernels BEFORE block upload.
@@ -1255,12 +1234,20 @@ impl InstructPipeline {
                     Arc::clone(&ctx),
                     input_norm,
                     post_attn_norm,
-                    w_q, w_k, w_v, w_o,
-                    w_gate, w_up, w_down,
+                    w_q,
+                    w_k,
+                    w_v,
+                    w_o,
+                    w_gate,
+                    w_up,
+                    w_down,
                     max_seq_len,
-                    q_lora, v_lora,
-                    lora_scale, lora_rank,
-                ).map(CudaBlock::Nf4)
+                    q_lora,
+                    v_lora,
+                    lora_scale,
+                    lora_rank,
+                )
+                .map(CudaBlock::Nf4)
             } else {
                 CudaTransformerBlock::new(
                     model_config,
@@ -1268,10 +1255,16 @@ impl InstructPipeline {
                     Arc::clone(&ctx),
                     input_norm,
                     post_attn_norm,
-                    w_q, w_k, w_v, w_o,
-                    w_gate, w_up, w_down,
+                    w_q,
+                    w_k,
+                    w_v,
+                    w_o,
+                    w_gate,
+                    w_up,
+                    w_down,
                     max_seq_len,
-                ).map(CudaBlock::Fp32)
+                )
+                .map(CudaBlock::Fp32)
             };
 
             match result {
@@ -1363,9 +1356,12 @@ impl InstructPipeline {
         let embed_data = model.embed_tokens.weight.data();
         let embed_slice = embed_data.as_slice().expect("contiguous embed");
 
-        let embed_original = trainer.upload(embed_slice).map_err(|e| {
-            eprintln!("[CUDA] embed_original upload failed: {e}");
-        }).ok()?;
+        let embed_original = trainer
+            .upload(embed_slice)
+            .map_err(|e| {
+                eprintln!("[CUDA] embed_original upload failed: {e}");
+            })
+            .ok()?;
 
         let mut embed_t = vec![0.0f32; hidden_size * vocab_size];
         for v in 0..vocab_size {
@@ -1373,14 +1369,20 @@ impl InstructPipeline {
                 embed_t[k * vocab_size + v] = embed_slice[v * hidden_size + k];
             }
         }
-        let embed_transposed = trainer.upload(&embed_t).map_err(|e| {
-            eprintln!("[CUDA] embed_transposed upload failed: {e}");
-        }).ok()?;
+        let embed_transposed = trainer
+            .upload(&embed_t)
+            .map_err(|e| {
+                eprintln!("[CUDA] embed_transposed upload failed: {e}");
+            })
+            .ok()?;
 
         // Logits scratch: [max_seq_len, vocab_size]
-        let logits_buf = trainer.zeros(max_seq_len * vocab_size).map_err(|e| {
-            eprintln!("[CUDA] logits_buf alloc failed: {e}");
-        }).ok()?;
+        let logits_buf = trainer
+            .zeros(max_seq_len * vocab_size)
+            .map_err(|e| {
+                eprintln!("[CUDA] logits_buf alloc failed: {e}");
+            })
+            .ok()?;
 
         // Grad-hidden scratch: [max_seq_len, hidden_size]
         let grad_hidden_buf = trainer.zeros(buf_size).ok()?;
@@ -1437,17 +1439,14 @@ impl InstructPipeline {
             None => return (None, None),
         };
 
-        let grad_ws = match CudaLoraGradWorkspace::new(
-            trainer.context(),
-            model_config,
-            config.lora_rank,
-        ) {
-            Ok(ws) => ws,
-            Err(e) => {
-                eprintln!("[CUDA] NF4 LoRA grad workspace alloc failed: {e}");
-                return (None, None);
-            }
-        };
+        let grad_ws =
+            match CudaLoraGradWorkspace::new(trainer.context(), model_config, config.lora_rank) {
+                Ok(ws) => ws,
+                Err(e) => {
+                    eprintln!("[CUDA] NF4 LoRA grad workspace alloc failed: {e}");
+                    return (None, None);
+                }
+            };
 
         let mut opt_states = Vec::with_capacity(blocks.len());
         for (i, block) in blocks.iter().enumerate() {
@@ -1483,14 +1482,13 @@ impl InstructPipeline {
     ) -> Option<()> {
         let seq_len = token_ids.len();
         let hidden_size = model.config.hidden_size;
-        let max_seq_len = model.config.max_position_embeddings.min(
-            training_state.layer_inputs.first().map_or(seq_len, |b| b.len() / hidden_size)
-        );
+        let max_seq_len = model
+            .config
+            .max_position_embeddings
+            .min(training_state.layer_inputs.first().map_or(seq_len, |b| b.len() / hidden_size));
 
         if seq_len > max_seq_len {
-            eprintln!(
-                "[CUDA] seq_len ({seq_len}) > max_seq_len ({max_seq_len}), truncating"
-            );
+            eprintln!("[CUDA] seq_len ({seq_len}) > max_seq_len ({max_seq_len}), truncating");
             return None;
         }
 
@@ -1504,14 +1502,20 @@ impl InstructPipeline {
         // KAIZEN-062: Upload hidden states into pre-allocated GPU buffer.
         // Partial write via copy_from_host_at — padded positions are irrelevant
         // (block.forward uses seq_len for attention masking and GEMM dimensions).
-        training_state.fwd_scratch_a.copy_from_host_at(hidden_slice, 0).map_err(|e| {
-            eprintln!("[CUDA] upload failed: {e}");
-        }).ok()?;
+        training_state
+            .fwd_scratch_a
+            .copy_from_host_at(hidden_slice, 0)
+            .map_err(|e| {
+                eprintln!("[CUDA] upload failed: {e}");
+            })
+            .ok()?;
 
         // KAIZEN-062: Ping-pong with pre-allocated forward scratch buffers.
         // Eliminates 2× cuMemAlloc + 2× cuMemFree per forward pass.
-        let scratch_a_ptr: *mut GpuBuffer<f32> = std::ptr::from_mut(&mut training_state.fwd_scratch_a);
-        let scratch_b_ptr: *mut GpuBuffer<f32> = std::ptr::from_mut(&mut training_state.fwd_scratch_b);
+        let scratch_a_ptr: *mut GpuBuffer<f32> =
+            std::ptr::from_mut(&mut training_state.fwd_scratch_a);
+        let scratch_b_ptr: *mut GpuBuffer<f32> =
+            std::ptr::from_mut(&mut training_state.fwd_scratch_b);
         let mut input_is_a = true;
 
         // Run through CUDA transformer blocks, saving inputs
@@ -1530,18 +1534,23 @@ impl InstructPipeline {
             // Save input for backward pass
             // SAFETY: layer_inputs[i] is a disjoint field from fwd_scratch_a/b.
             unsafe {
-                if let Err(e) = training_state.layer_inputs[i]
-                    .copy_from_buffer_async(gpu_input, stream)
+                if let Err(e) =
+                    training_state.layer_inputs[i].copy_from_buffer_async(gpu_input, stream)
                 {
-                    eprintln!("[CUDA] Layer {i} input save failed: {e} (src={}, dst={})",
-                        gpu_input.len(), training_state.layer_inputs[i].len());
+                    eprintln!(
+                        "[CUDA] Layer {i} input save failed: {e} (src={}, dst={})",
+                        gpu_input.len(),
+                        training_state.layer_inputs[i].len()
+                    );
                     return None;
                 }
             }
 
             // Forward uses actual seq_len for attention masking; padded positions
             // produce zeros that don't affect loss (loss only covers actual tokens).
-            if let Err(e) = block.forward(gpu_input, gpu_output, seq_len, stream, shared_scratch.as_mut()) {
+            if let Err(e) =
+                block.forward(gpu_input, gpu_output, seq_len, stream, shared_scratch.as_mut())
+            {
                 eprintln!("[CUDA] Layer {i} forward failed: {e}");
                 return None;
             }
@@ -1550,14 +1559,18 @@ impl InstructPipeline {
 
         // After ping-pong: result is in the buffer that would be "input" for the next iteration
         let final_output = unsafe {
-            if input_is_a { &*scratch_a_ptr } else { &*scratch_b_ptr }
+            if input_is_a {
+                &*scratch_a_ptr
+            } else {
+                &*scratch_b_ptr
+            }
         };
 
         // Save blocks output for RMSNorm backward
         // SAFETY: blocks_output is a disjoint field from fwd_scratch_a/b.
         unsafe {
-            if let Err(e) = training_state.blocks_output
-                .copy_from_buffer_async(final_output, stream)
+            if let Err(e) =
+                training_state.blocks_output.copy_from_buffer_async(final_output, stream)
             {
                 eprintln!("[CUDA] blocks_output save failed: {e}");
                 return None;
@@ -1574,9 +1587,11 @@ impl InstructPipeline {
             seq_len as u32,
             hidden_size as u32,
             stream,
-        ).map_err(|e| {
+        )
+        .map_err(|e| {
             eprintln!("[CUDA] GPU RMSNorm forward failed: {e}");
-        }).ok()?;
+        })
+        .ok()?;
 
         Some(())
     }
@@ -1588,11 +1603,7 @@ impl InstructPipeline {
     /// step (grad workspace is shared across layers).
     #[cfg(feature = "cuda")]
     #[allow(unsafe_code)]
-    fn backward_nf4_gpu_blocks(
-        &mut self,
-        grad_final_hidden: &[f32],
-        seq_len: usize,
-    ) -> Option<()> {
+    fn backward_nf4_gpu_blocks(&mut self, grad_final_hidden: &[f32], seq_len: usize) -> Option<()> {
         let hidden_size = self.model.config.hidden_size;
 
         // Upload gradient and run RMSNorm backward in a scope to release borrows
@@ -1616,7 +1627,8 @@ impl InstructPipeline {
                 hidden_size as u32,
                 1e-5_f32,
                 stream,
-            ).ok()?;
+            )
+            .ok()?;
         }
 
         self.backward_nf4_gpu_blocks_loop(seq_len)
@@ -1632,10 +1644,7 @@ impl InstructPipeline {
     /// - 1× Vec<f32> heap allocation (~5MB)
     #[cfg(feature = "cuda")]
     #[allow(unsafe_code)]
-    fn backward_nf4_gpu_blocks_gpu_resident(
-        &mut self,
-        seq_len: usize,
-    ) -> Option<()> {
+    fn backward_nf4_gpu_blocks_gpu_resident(&mut self, seq_len: usize) -> Option<()> {
         let hidden_size = self.model.config.hidden_size;
 
         // KAIZEN-065: grad_hidden_buf already contains the gradient from lm_head backward GEMM.
@@ -1657,7 +1666,8 @@ impl InstructPipeline {
                 hidden_size as u32,
                 1e-5_f32,
                 stream,
-            ).ok()?;
+            )
+            .ok()?;
         }
 
         self.backward_nf4_gpu_blocks_loop(seq_len)
@@ -1667,10 +1677,7 @@ impl InstructPipeline {
     /// GPU-resident backward paths after RMSNorm backward completes.
     #[cfg(feature = "cuda")]
     #[allow(unsafe_code)]
-    fn backward_nf4_gpu_blocks_loop(
-        &mut self,
-        seq_len: usize,
-    ) -> Option<()> {
+    fn backward_nf4_gpu_blocks_loop(&mut self, seq_len: usize) -> Option<()> {
         let trainer = self.cuda_trainer.as_ref()?;
         let lr = self.optimizer.lr();
         let stream = trainer.stream();
@@ -1692,7 +1699,8 @@ impl InstructPipeline {
         let step = self.nf4_lora_step;
 
         // KAIZEN-045: Use pre-allocated output_scratch from training state
-        let output_scratch_ptr: *mut GpuBuffer<f32> = std::ptr::from_mut(&mut training_state.output_scratch);
+        let output_scratch_ptr: *mut GpuBuffer<f32> =
+            std::ptr::from_mut(&mut training_state.output_scratch);
 
         for layer_idx in (0..num_layers).rev() {
             // SAFETY: grad_a_ptr and grad_b_ptr point to disjoint fields.
@@ -1705,29 +1713,33 @@ impl InstructPipeline {
             };
 
             // SAFETY: output_scratch_ptr points to a disjoint field of training_state.
-            blocks[layer_idx].backward_nf4(
-                &training_state.layer_inputs[layer_idx],
-                grad_output,
-                grad_input,
-                unsafe { &mut *output_scratch_ptr },
-                seq_len,
-                stream,
-                shared_scratch,
-                grad_lora,
-            ).ok()?;
+            blocks[layer_idx]
+                .backward_nf4(
+                    &training_state.layer_inputs[layer_idx],
+                    grad_output,
+                    grad_input,
+                    unsafe { &mut *output_scratch_ptr },
+                    seq_len,
+                    stream,
+                    shared_scratch,
+                    grad_lora,
+                )
+                .ok()?;
 
             // Immediately apply LoRA optimizer step
-            blocks[layer_idx].lora_optimizer_step(
-                &mut opt_states[layer_idx],
-                step,
-                lr,
-                0.9,    // beta1
-                0.999,  // beta2
-                1e-8,   // eps
-                0.01,   // weight_decay
-                stream,
-                grad_lora,
-            ).ok()?;
+            blocks[layer_idx]
+                .lora_optimizer_step(
+                    &mut opt_states[layer_idx],
+                    step,
+                    lr,
+                    0.9,   // beta1
+                    0.999, // beta2
+                    1e-8,  // eps
+                    0.01,  // weight_decay
+                    stream,
+                    grad_lora,
+                )
+                .ok()?;
 
             grad_output_is_a = !grad_output_is_a;
         }
@@ -1758,7 +1770,9 @@ impl InstructPipeline {
 
         let stream = trainer.stream();
         for (i, block) in cuda_blocks.iter_mut().enumerate() {
-            if let Err(e) = block.forward(&gpu_input, &mut gpu_output, seq_len, stream, shared_scratch.as_mut()) {
+            if let Err(e) =
+                block.forward(&gpu_input, &mut gpu_output, seq_len, stream, shared_scratch.as_mut())
+            {
                 eprintln!("[CUDA] Layer {i} forward failed: {e}");
                 return None;
             }
@@ -1817,13 +1831,21 @@ impl InstructPipeline {
                 _ => return None,
             };
             let normed_hidden = Self::forward_cuda_inference(
-                &self.model, token_ids, trainer, blocks, &mut self.shared_scratch,
+                &self.model,
+                token_ids,
+                trainer,
+                blocks,
+                &mut self.shared_scratch,
             )?;
             // Inference path: upload CPU normed hidden to GPU
             let training = self.gpu_training.as_mut()?;
-            training.lm_head_hidden_buf.copy_from_host_at(&normed_hidden, 0).map_err(|e| {
-                eprintln!("[CUDA] lm_head forward: hidden upload failed: {e}");
-            }).ok()?;
+            training
+                .lm_head_hidden_buf
+                .copy_from_host_at(&normed_hidden, 0)
+                .map_err(|e| {
+                    eprintln!("[CUDA] lm_head forward: hidden upload failed: {e}");
+                })
+                .ok()?;
         }
 
         // GPU GEMM: logits[seq, vocab] = hidden[seq, hidden] @ embed_T[hidden, vocab]
@@ -1850,9 +1872,12 @@ impl InstructPipeline {
         }
 
         // Download only the logits we need (seq_len * vocab_size), not the full max_seq_len buffer
-        let full_logits = trainer.download(&training.logits_buf).map_err(|e| {
-            eprintln!("[CUDA] lm_head forward: logits download failed: {e}");
-        }).ok()?;
+        let full_logits = trainer
+            .download(&training.logits_buf)
+            .map_err(|e| {
+                eprintln!("[CUDA] lm_head forward: logits download failed: {e}");
+            })
+            .ok()?;
 
         Some(full_logits[..seq_len * vocab_size].to_vec())
     }
@@ -1895,7 +1920,11 @@ impl InstructPipeline {
                 _ => return false,
             };
             let normed_hidden = match Self::forward_cuda_inference(
-                &self.model, token_ids, trainer, blocks, &mut self.shared_scratch,
+                &self.model,
+                token_ids,
+                trainer,
+                blocks,
+                &mut self.shared_scratch,
             ) {
                 Some(h) => h,
                 None => return false,
@@ -1926,7 +1955,9 @@ impl InstructPipeline {
             hidden_size as u32,
             vocab_size as u32,
             stream,
-        ).is_err() {
+        )
+        .is_err()
+        {
             eprintln!("[CUDA] lm_head forward GEMM failed");
             return false;
         }
@@ -1996,10 +2027,7 @@ mod tests {
     #[test]
     fn test_instruct_pipeline_new() {
         let model_config = TransformerConfig::tiny();
-        let instruct_config = InstructConfig {
-            lora_rank: 4,
-            ..InstructConfig::default()
-        };
+        let instruct_config = InstructConfig { lora_rank: 4, ..InstructConfig::default() };
         let pipeline = InstructPipeline::new(&model_config, instruct_config);
         // 2 layers * 2 (Q+V) = 4 LoRA layers for tiny config
         assert_eq!(pipeline.lora_layers.len(), 4);
@@ -2008,11 +2036,8 @@ mod tests {
     #[test]
     fn test_instruct_train_step() {
         let model_config = TransformerConfig::tiny();
-        let instruct_config = InstructConfig {
-            lora_rank: 4,
-            max_seq_len: 64,
-            ..InstructConfig::default()
-        };
+        let instruct_config =
+            InstructConfig { lora_rank: 4, max_seq_len: 64, ..InstructConfig::default() };
         let mut pipeline = InstructPipeline::new(&model_config, instruct_config);
 
         let prompt_ids: Vec<u32> = (0..10).collect();
@@ -2027,11 +2052,8 @@ mod tests {
     #[test]
     fn test_instruct_evaluate() {
         let model_config = TransformerConfig::tiny();
-        let instruct_config = InstructConfig {
-            lora_rank: 4,
-            max_seq_len: 64,
-            ..InstructConfig::default()
-        };
+        let instruct_config =
+            InstructConfig { lora_rank: 4, max_seq_len: 64, ..InstructConfig::default() };
         let pipeline = InstructPipeline::new(&model_config, instruct_config);
 
         let prompts = vec![vec![0u32, 1, 2, 3, 4]];
@@ -2045,11 +2067,8 @@ mod tests {
     #[test]
     fn test_empty_response_noop() {
         let model_config = TransformerConfig::tiny();
-        let instruct_config = InstructConfig {
-            lora_rank: 4,
-            max_seq_len: 64,
-            ..InstructConfig::default()
-        };
+        let instruct_config =
+            InstructConfig { lora_rank: 4, max_seq_len: 64, ..InstructConfig::default() };
         let mut pipeline = InstructPipeline::new(&model_config, instruct_config);
 
         let result = pipeline.train_step(&[0, 1, 2], &[]);

--- a/src/finetune/instruct_trainer.rs
+++ b/src/finetune/instruct_trainer.rs
@@ -124,9 +124,7 @@ impl InstructTrainer {
         config: InstructTrainingConfig,
     ) -> crate::Result<Self> {
         if corpus.is_empty() {
-            return Err(crate::Error::ConfigError(
-                "GH-371: corpus must not be empty".to_string(),
-            ));
+            return Err(crate::Error::ConfigError("GH-371: corpus must not be empty".to_string()));
         }
         if config.val_split <= 0.0 || config.val_split > 0.5 {
             return Err(crate::Error::ConfigError(format!(
@@ -135,13 +133,10 @@ impl InstructTrainer {
             )));
         }
         if config.epochs == 0 {
-            return Err(crate::Error::ConfigError(
-                "GH-371: epochs must be > 0".to_string(),
-            ));
+            return Err(crate::Error::ConfigError("GH-371: epochs must be > 0".to_string()));
         }
 
-        let (train_data, val_data) =
-            Self::split_dataset(&corpus, config.val_split, config.seed);
+        let (train_data, val_data) = Self::split_dataset(&corpus, config.val_split, config.seed);
 
         if train_data.is_empty() || val_data.is_empty() {
             return Err(crate::Error::ConfigError(format!(
@@ -154,14 +149,7 @@ impl InstructTrainer {
         let rng_seed = config.seed;
         let data_hash = Self::compute_data_hash(&corpus);
 
-        Ok(Self {
-            pipeline,
-            config,
-            train_data,
-            val_data,
-            rng_seed,
-            data_hash,
-        })
+        Ok(Self { pipeline, config, train_data, val_data, rng_seed, data_hash })
     }
 
     /// Run the full training loop.
@@ -210,20 +198,13 @@ impl InstructTrainer {
                 let lr = scheduler.get_lr();
                 self.pipeline.set_learning_rate(lr);
 
-                let result = self.pipeline.train_step(
-                    &sample.prompt_ids,
-                    &sample.response_ids,
-                );
+                let result = self.pipeline.train_step(&sample.prompt_ids, &sample.response_ids);
                 epoch_loss += result.loss * result.num_response_tokens as f32;
                 epoch_tokens += result.num_response_tokens;
                 scheduler.step();
             }
 
-            let train_loss = if epoch_tokens > 0 {
-                epoch_loss / epoch_tokens as f32
-            } else {
-                0.0
-            };
+            let train_loss = if epoch_tokens > 0 { epoch_loss / epoch_tokens as f32 } else { 0.0 };
 
             // ── Validate ──
             // KAIZEN-046: val_prompts/val_responses hoisted outside epoch loop.
@@ -396,10 +377,7 @@ impl InstructTrainer {
         self.pipeline.sync_lora_to_cpu();
 
         std::fs::create_dir_all(path).map_err(|e| {
-            crate::Error::Io(format!(
-                "Failed to create checkpoint dir {}: {e}",
-                path.display()
-            ))
+            crate::Error::Io(format!("Failed to create checkpoint dir {}: {e}", path.display()))
         })?;
 
         // Save metadata.json
@@ -435,22 +413,14 @@ impl InstructTrainer {
             let a_bytes: Vec<u8> =
                 bytemuck::cast_slice(a_data.as_slice().expect("contiguous lora_a")).to_vec();
             let a_shape = vec![lora.rank(), lora.d_in()];
-            tensor_data.push((
-                format!("lora.{layer}.{proj}_proj.lora_a"),
-                a_bytes,
-                a_shape,
-            ));
+            tensor_data.push((format!("lora.{layer}.{proj}_proj.lora_a"), a_bytes, a_shape));
 
             // LoRA B: [d_out, rank]
             let b_data = lora.lora_b().data();
             let b_bytes: Vec<u8> =
                 bytemuck::cast_slice(b_data.as_slice().expect("contiguous lora_b")).to_vec();
             let b_shape = vec![lora.d_out(), lora.rank()];
-            tensor_data.push((
-                format!("lora.{layer}.{proj}_proj.lora_b"),
-                b_bytes,
-                b_shape,
-            ));
+            tensor_data.push((format!("lora.{layer}.{proj}_proj.lora_b"), b_bytes, b_shape));
         }
 
         let views: Vec<(&str, safetensors::tensor::TensorView<'_>)> = tensor_data
@@ -468,17 +438,11 @@ impl InstructTrainer {
 
         let mut st_metadata = std::collections::HashMap::new();
         st_metadata.insert("epoch".to_string(), epoch.to_string());
-        st_metadata.insert(
-            "val_loss".to_string(),
-            format!("{:.6}", metrics.val_loss),
-        );
+        st_metadata.insert("val_loss".to_string(), format!("{:.6}", metrics.val_loss));
 
-        let safetensor_bytes =
-            safetensors::serialize(views, Some(st_metadata)).map_err(|e| {
-                crate::Error::Serialization(format!(
-                    "SafeTensors serialization failed: {e}"
-                ))
-            })?;
+        let safetensor_bytes = safetensors::serialize(views, Some(st_metadata)).map_err(|e| {
+            crate::Error::Serialization(format!("SafeTensors serialization failed: {e}"))
+        })?;
         std::fs::write(path.join("model.safetensors"), safetensor_bytes)?;
 
         Ok(())
@@ -505,17 +469,11 @@ mod tests {
     #[test]
     fn test_trainer_creation() {
         let model_config = TransformerConfig::tiny();
-        let instruct_config = InstructConfig {
-            lora_rank: 4,
-            max_seq_len: 32,
-            ..InstructConfig::default()
-        };
+        let instruct_config =
+            InstructConfig { lora_rank: 4, max_seq_len: 32, ..InstructConfig::default() };
         let pipeline = InstructPipeline::new(&model_config, instruct_config);
         let corpus = make_corpus(20);
-        let config = InstructTrainingConfig {
-            epochs: 2,
-            ..Default::default()
-        };
+        let config = InstructTrainingConfig { epochs: 2, ..Default::default() };
 
         let trainer = InstructTrainer::new(pipeline, corpus, config);
         assert!(trainer.is_ok());
@@ -539,18 +497,11 @@ mod tests {
     #[test]
     fn test_trainer_train() {
         let model_config = TransformerConfig::tiny();
-        let instruct_config = InstructConfig {
-            lora_rank: 4,
-            max_seq_len: 32,
-            ..InstructConfig::default()
-        };
+        let instruct_config =
+            InstructConfig { lora_rank: 4, max_seq_len: 32, ..InstructConfig::default() };
         let pipeline = InstructPipeline::new(&model_config, instruct_config);
         let corpus = make_corpus(10);
-        let config = InstructTrainingConfig {
-            epochs: 2,
-            save_every: 1,
-            ..Default::default()
-        };
+        let config = InstructTrainingConfig { epochs: 2, save_every: 1, ..Default::default() };
 
         let mut trainer = InstructTrainer::new(pipeline, corpus, config).unwrap();
         let result = trainer.train();

--- a/src/finetune/mod.rs
+++ b/src/finetune/mod.rs
@@ -19,22 +19,22 @@ pub mod classification;
 pub mod classify_pipeline;
 pub mod classify_trainer;
 pub mod classify_tuner;
+mod corpus;
 pub mod data_parallel;
+mod device;
 pub mod distributed;
+mod eval;
 pub mod gradient_server;
-pub mod ring_allreduce;
-pub mod worker_client;
 pub mod instruct_corpus;
 pub mod instruct_pipeline;
 pub mod instruct_trainer;
 pub mod multi_adapter_pipeline;
-pub mod training_plan;
-pub mod tune_searchers;
-mod corpus;
-mod device;
-mod eval;
 mod popperian;
 mod reproducibility;
+pub mod ring_allreduce;
+pub mod training_plan;
+pub mod tune_searchers;
+pub mod worker_client;
 
 #[cfg(test)]
 mod tests;
@@ -47,8 +47,8 @@ pub use classification::{
     MultiLabelSafetySample, SafetyCorpusStats, SafetySample, TokenizedSample,
 };
 pub use classify_pipeline::{
-    BatchResult, ClassifyConfig, ClassifyPipeline, DataStats, DiagSeverity,
-    HyperparamDiagnostic, HyperparamDiagnostics,
+    BatchResult, ClassifyConfig, ClassifyPipeline, DataStats, DiagSeverity, HyperparamDiagnostic,
+    HyperparamDiagnostics,
 };
 pub use classify_trainer::{
     evaluate_checkpoint, ClassifyEvalReport, ClassifyTrainer, EpochMetrics, TrainResult,
@@ -59,6 +59,18 @@ pub use classify_tuner::{
     TrialSummary, TuneConfig, TuneResult, TuneScheduler, TuneSearcher, TuneStrategy,
 };
 pub use corpus::{CorpusStats, SampleMetadata, TestGenCorpus, TestGenSample};
+pub use data_parallel::{
+    average_gradients, has_non_finite, shard_samples, DataParallelCoordinator,
+};
+pub use device::{ComputeDevice, DeviceInfo};
+pub use distributed::{DistributedConfig, NodeRole, WireMessage};
+pub use eval::{
+    contains_tautology, count_test_functions, has_edge_case_tests, has_meaningful_assertions,
+    EvalMetrics, EvalResult, TestEvaluator,
+};
+pub use gradient_server::{
+    AllReduceResult, BlockAllReduceResult, GradientServer, NonBlockAllReduceResult,
+};
 pub use instruct_corpus::{
     format_chat_prompt, instruct_corpus_stats, load_instruct_corpus, InstructCorpusStats,
     InstructMetadata, InstructSample,
@@ -72,24 +84,14 @@ pub use instruct_trainer::{
 pub use multi_adapter_pipeline::{
     AdapterConfig, AdapterSchedule, AdapterSlot, MultiAdapterPipeline,
 };
-pub use data_parallel::{DataParallelCoordinator, average_gradients, has_non_finite, shard_samples};
-pub use device::{ComputeDevice, DeviceInfo};
-pub use distributed::{DistributedConfig, NodeRole, WireMessage};
-pub use gradient_server::{
-    AllReduceResult, BlockAllReduceResult, GradientServer, NonBlockAllReduceResult,
-};
-pub use ring_allreduce::{allreduce_pair, RingAllReduceWorker};
-pub use worker_client::{
-    AveragedBlockResult, AveragedNonBlockResult, AveragedResult, ShardAssignment, WorkerClient,
-};
-pub use eval::{
-    contains_tautology, count_test_functions, has_edge_case_tests, has_meaningful_assertions,
-    EvalMetrics, EvalResult, TestEvaluator,
-};
 pub use popperian::{PopperianQA, QAGrade};
 pub use reproducibility::{ExperimentLock, ReproducibilityConfig};
+pub use ring_allreduce::{allreduce_pair, RingAllReduceWorker};
 pub use training_plan::{
-    execute_plan, plan as training_plan, ApplyConfig, CheckStatus, DataAudit,
-    HyperparameterPlan, ManualConfig, ModelInfo, PlanConfig, PlanIssue, PlanVerdict,
-    PreFlightCheck, ResourceEstimate, TrainingPlan, TrialPreview,
+    execute_plan, plan as training_plan, ApplyConfig, CheckStatus, DataAudit, HyperparameterPlan,
+    ManualConfig, ModelInfo, PlanConfig, PlanIssue, PlanVerdict, PreFlightCheck, ResourceEstimate,
+    TrainingPlan, TrialPreview,
+};
+pub use worker_client::{
+    AveragedBlockResult, AveragedNonBlockResult, AveragedResult, ShardAssignment, WorkerClient,
 };

--- a/src/finetune/multi_adapter_pipeline.rs
+++ b/src/finetune/multi_adapter_pipeline.rs
@@ -37,8 +37,7 @@ use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
 /// Scheduling strategy for multi-adapter training.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AdapterSchedule {
     /// All adapters process one sample each per step (synchronized).
     Synchronized,
@@ -48,7 +47,6 @@ pub enum AdapterSchedule {
     /// Priority: adapter with highest validation loss gets the next step.
     PriorityValLoss,
 }
-
 
 /// Configuration for a single adapter slot.
 #[derive(Debug, Clone)]
@@ -206,12 +204,7 @@ impl MultiAdapterPipeline {
     /// (with CUDA blocks uploaded if GPU training is desired). Adapter slots
     /// are initially empty — call `add_adapter()` to register each one.
     pub fn new(base_pipeline: InstructPipeline, schedule: AdapterSchedule) -> Self {
-        Self {
-            base_pipeline,
-            adapters: Vec::new(),
-            schedule,
-            global_step: 0,
-        }
+        Self { base_pipeline, adapters: Vec::new(), schedule, global_step: 0 }
     }
 
     /// Add an adapter slot with its own training data and checkpoint directory.
@@ -261,9 +254,7 @@ impl MultiAdapterPipeline {
                 // All adapters train — caller should iterate all
                 Some(0)
             }
-            AdapterSchedule::RoundRobin => {
-                Some(self.global_step % self.adapters.len())
-            }
+            AdapterSchedule::RoundRobin => Some(self.global_step % self.adapters.len()),
             AdapterSchedule::PriorityValLoss => {
                 // Pick adapter with highest (worst) validation loss
                 self.adapters
@@ -314,9 +305,7 @@ impl MultiAdapterPipeline {
         std::mem::swap(&mut slot.lora_layers, &mut self.base_pipeline.lora_layers);
 
         // Run training step through base pipeline (uses shared CUDA blocks)
-        let result = self
-            .base_pipeline
-            .train_step(&prompt_ids, &response_ids);
+        let result = self.base_pipeline.train_step(&prompt_ids, &response_ids);
 
         // Swap LoRA layers back
         std::mem::swap(&mut slot.lora_layers, &mut self.base_pipeline.lora_layers);
@@ -337,9 +326,7 @@ impl MultiAdapterPipeline {
 
     /// Check if all adapters have exhausted their training data.
     pub fn all_exhausted(&self) -> bool {
-        self.adapters
-            .iter()
-            .all(|s| s.cursor >= s.train_samples.len())
+        self.adapters.iter().all(|s| s.cursor >= s.train_samples.len())
     }
 
     /// Batch training step across all non-exhausted adapters (GH-204).
@@ -403,10 +390,7 @@ impl MultiAdapterPipeline {
             "train_samples": slot.train_samples.len(),
             "global_step": self.global_step,
         });
-        std::fs::write(
-            ckpt_dir.join("metadata.json"),
-            serde_json::to_string_pretty(&metadata)?,
-        )?;
+        std::fs::write(ckpt_dir.join("metadata.json"), serde_json::to_string_pretty(&metadata)?)?;
 
         // Save LoRA weights as SafeTensors
         save_adapter_lora_weights(&slot.lora_layers, &ckpt_dir)?;
@@ -434,10 +418,7 @@ impl MultiAdapterPipeline {
             "lora_alpha": slot.config.lora_alpha,
             "global_step": self.global_step,
         });
-        std::fs::write(
-            best_dir.join("metadata.json"),
-            serde_json::to_string_pretty(&metadata)?,
-        )?;
+        std::fs::write(best_dir.join("metadata.json"), serde_json::to_string_pretty(&metadata)?)?;
 
         save_adapter_lora_weights(&slot.lora_layers, &best_dir)?;
         Ok(best_dir)
@@ -518,16 +499,10 @@ mod tests {
 
         assert_eq!(pipeline.select_next_adapter(), Some(0));
 
-        let pipeline = MultiAdapterPipeline {
-            global_step: 1,
-            ..pipeline
-        };
+        let pipeline = MultiAdapterPipeline { global_step: 1, ..pipeline };
         assert_eq!(pipeline.select_next_adapter(), Some(1));
 
-        let pipeline = MultiAdapterPipeline {
-            global_step: 5,
-            ..pipeline
-        };
+        let pipeline = MultiAdapterPipeline { global_step: 5, ..pipeline };
         assert_eq!(pipeline.select_next_adapter(), Some(2));
     }
 

--- a/src/finetune/ring_allreduce.rs
+++ b/src/finetune/ring_allreduce.rs
@@ -52,12 +52,7 @@ impl RingAllReduceWorker {
     ) -> Self {
         assert!(world_size >= 2, "ring AllReduce requires >= 2 workers");
         assert!(rank < world_size, "rank must be < world_size");
-        Self {
-            rank,
-            world_size,
-            send_stream,
-            recv_stream,
-        }
+        Self { rank, world_size, send_stream, recv_stream }
     }
 
     /// Perform AllReduce on `data`, returning the averaged result.
@@ -118,11 +113,8 @@ impl RingAllReduceWorker {
 
             // Element-wise add received chunk into local chunk
             for i in 0..recv_len {
-                let received = f32::from_le_bytes(
-                    recv_buf[i * 4..(i + 1) * 4]
-                        .try_into()
-                        .expect("4 bytes"),
-                );
+                let received =
+                    f32::from_le_bytes(recv_buf[i * 4..(i + 1) * 4].try_into().expect("4 bytes"));
                 data[recv_start + i] += received;
             }
         }
@@ -148,11 +140,8 @@ impl RingAllReduceWorker {
 
             // Copy received chunk into place (no addition — just replace)
             for i in 0..recv_len {
-                data[recv_start + i] = f32::from_le_bytes(
-                    recv_buf[i * 4..(i + 1) * 4]
-                        .try_into()
-                        .expect("4 bytes"),
-                );
+                data[recv_start + i] =
+                    f32::from_le_bytes(recv_buf[i * 4..(i + 1) * 4].try_into().expect("4 bytes"));
             }
         }
 
@@ -192,16 +181,11 @@ pub fn allreduce_pair(
 
     f32_slice_to_bytes(data, &mut send_buf);
 
-    send_stream
-        .write_all(&send_buf)
-        .map_err(|e| format!("pair send error: {e}"))?;
-    recv_stream
-        .read_exact(&mut recv_buf)
-        .map_err(|e| format!("pair recv error: {e}"))?;
+    send_stream.write_all(&send_buf).map_err(|e| format!("pair send error: {e}"))?;
+    recv_stream.read_exact(&mut recv_buf).map_err(|e| format!("pair recv error: {e}"))?;
 
     for i in 0..data.len() {
-        let remote =
-            f32::from_le_bytes(recv_buf[i * 4..(i + 1) * 4].try_into().expect("4 bytes"));
+        let remote = f32::from_le_bytes(recv_buf[i * 4..(i + 1) * 4].try_into().expect("4 bytes"));
         data[i] = (data[i] + remote) * 0.5;
     }
 
@@ -218,9 +202,8 @@ mod tests {
     /// Returns N `RingAllReduceWorker` instances.
     fn setup_ring(n: usize) -> Vec<RingAllReduceWorker> {
         // Create N listeners
-        let listeners: Vec<TcpListener> = (0..n)
-            .map(|_| TcpListener::bind("127.0.0.1:0").expect("bind"))
-            .collect();
+        let listeners: Vec<TcpListener> =
+            (0..n).map(|_| TcpListener::bind("127.0.0.1:0").expect("bind")).collect();
         let addrs: Vec<_> = listeners.iter().map(|l| l.local_addr().expect("addr")).collect();
 
         // Each worker connects to its right neighbor
@@ -383,7 +366,8 @@ mod tests {
         let r2 = h2.join().expect("join");
 
         // Expected: (d0 + d1 + d2) / 3
-        let expected: Vec<f32> = vec![8.0 / 3.0, 8.0 / 3.0, 8.0 / 3.0, 8.0 / 3.0, 8.0 / 3.0, 8.0 / 3.0, 8.0 / 3.0];
+        let expected: Vec<f32> =
+            vec![8.0 / 3.0, 8.0 / 3.0, 8.0 / 3.0, 8.0 / 3.0, 8.0 / 3.0, 8.0 / 3.0, 8.0 / 3.0];
         for (i, (&v, &e)) in d0.iter().zip(&expected).enumerate() {
             assert!((v - e).abs() < 1e-5, "w0[{i}]: {v} != {e}");
         }
@@ -410,10 +394,7 @@ mod tests {
 
         let expected = (d as f32 - 1.0) / 2.0;
         for (i, &v) in d0.iter().enumerate() {
-            assert!(
-                (v - expected).abs() < 1e-2,
-                "w0[{i}]: {v} != {expected}"
-            );
+            assert!((v - expected).abs() < 1e-2, "w0[{i}]: {v} != {expected}");
         }
         assert_eq!(d0, r1, "results must be identical");
     }

--- a/src/finetune/training_plan.rs
+++ b/src/finetune/training_plan.rs
@@ -332,10 +332,7 @@ pub fn plan(config: &PlanConfig) -> crate::Result<TrainingPlan> {
     //
     // For HPO, use the median batch size from search space (64) to get a
     // representative estimate. For manual, use the configured batch size.
-    let batch_size = hyperparameters
-        .manual
-        .as_ref()
-        .map_or(64, |m| m.batch_size);
+    let batch_size = hyperparameters.manual.as_ref().map_or(64, |m| m.batch_size);
     let resources = estimate_resources(config, &model, &data, batch_size);
 
     // ── 5. Additional pre-flight checks ────────────────────────────────
@@ -370,10 +367,7 @@ pub fn plan(config: &PlanConfig) -> crate::Result<TrainingPlan> {
         pre_flight.push(PreFlightCheck {
             name: "output_dir".to_string(),
             status: CheckStatus::Pass,
-            detail: format!(
-                "Output directory {} will be created",
-                config.output_dir.display()
-            ),
+            detail: format!("Output directory {} will be created", config.output_dir.display()),
         });
     }
 
@@ -444,21 +438,12 @@ fn audit_data(
     pre_flight.push(PreFlightCheck {
         name: "data_file".to_string(),
         status: CheckStatus::Pass,
-        detail: format!(
-            "{} samples loaded from {}",
-            stats.total,
-            config.data_path.display()
-        ),
+        detail: format!("{} samples loaded from {}", stats.total, config.data_path.display()),
     });
 
     // Check for empty classes
-    let empty_classes: Vec<usize> = stats
-        .class_counts
-        .iter()
-        .enumerate()
-        .filter(|(_, &c)| c == 0)
-        .map(|(i, _)| i)
-        .collect();
+    let empty_classes: Vec<usize> =
+        stats.class_counts.iter().enumerate().filter(|(_, &c)| c == 0).map(|(i, _)| i).collect();
     if empty_classes.is_empty() {
         pre_flight.push(PreFlightCheck {
             name: "class_coverage".to_string(),
@@ -508,7 +493,10 @@ fn audit_data(
         issues.push(PlanIssue {
             severity: CheckStatus::Warn,
             category: "Data".to_string(),
-            message: format!("{duplicates} duplicate inputs detected ({:.1}%)", duplicates as f64 / stats.total as f64 * 100.0),
+            message: format!(
+                "{duplicates} duplicate inputs detected ({:.1}%)",
+                duplicates as f64 / stats.total as f64 * 100.0
+            ),
             fix: Some("Remove duplicates: apr data dedup".to_string()),
         });
     }
@@ -609,10 +597,7 @@ fn resolve_model(config: &PlanConfig, pre_flight: &mut Vec<PreFlightCheck>) -> M
                 pre_flight.push(PreFlightCheck {
                     name: "model_weights".to_string(),
                     status: CheckStatus::Warn,
-                    detail: format!(
-                        "Model directory exists but missing: {}",
-                        missing.join(", ")
-                    ),
+                    detail: format!("Model directory exists but missing: {}", missing.join(", ")),
                 });
             }
         } else {
@@ -696,9 +681,7 @@ fn build_hpo_plan(
     }
 
     // Parse strategy for searcher
-    let tune_strategy: TuneStrategy = strategy
-        .parse()
-        .unwrap_or(TuneStrategy::Tpe);
+    let tune_strategy: TuneStrategy = strategy.parse().unwrap_or(TuneStrategy::Tpe);
 
     // Build searcher and sample configs
     let space = default_classify_search_space();
@@ -707,12 +690,8 @@ fn build_hpo_plan(
             let n_startup = (config.budget / 3).max(3);
             Box::new(super::tune_searchers::TpeSearcher::new(space.clone(), n_startup))
         }
-        TuneStrategy::Grid => {
-            Box::new(super::tune_searchers::GridSearcher::new(space.clone(), 3))
-        }
-        TuneStrategy::Random => {
-            Box::new(super::tune_searchers::RandomSearcher::new(space.clone()))
-        }
+        TuneStrategy::Grid => Box::new(super::tune_searchers::GridSearcher::new(space.clone(), 3)),
+        TuneStrategy::Random => Box::new(super::tune_searchers::RandomSearcher::new(space.clone())),
     };
 
     let num_previews = config.budget.min(3);
@@ -761,7 +740,9 @@ fn build_hpo_plan(
                 config.budget,
                 estimate_gpu_hours(train_samples, config.max_epochs, config.budget)
             ),
-            fix: Some("Use --scout for 1-epoch trials first, then --from-scout for full run".to_string()),
+            fix: Some(
+                "Use --scout for 1-epoch trials first, then --from-scout for full run".to_string(),
+            ),
         });
     }
 
@@ -810,19 +791,15 @@ fn estimate_resources(
     // (measured over 245 steps in v3 training run)
     // For larger models, scale by layer count ratio
     let seconds_per_step = match model.hidden_size {
-        896 => 58.0,    // 0.5B: observed on RTX 4090
-        4096 => 270.0,  // 7B/9B: estimated ~4.7x slower
-        5120 => 450.0,  // 13B: estimated ~7.8x slower
+        896 => 58.0,   // 0.5B: observed on RTX 4090
+        4096 => 270.0, // 7B/9B: estimated ~4.7x slower
+        5120 => 450.0, // 13B: estimated ~7.8x slower
         _ => 90.0,
     };
     let minutes_per_epoch = (steps_per_epoch as f64 * seconds_per_step) / 60.0;
 
     let total_epochs = if config.scout { 1 } else { config.max_epochs };
-    let total_trials = if config.strategy == "manual" {
-        1
-    } else {
-        config.budget
-    };
+    let total_trials = if config.strategy == "manual" { 1 } else { config.budget };
     let total_minutes = minutes_per_epoch * total_epochs as f64 * total_trials as f64;
 
     // Checkpoint size: LoRA adapters + classifier head
@@ -908,9 +885,9 @@ pub fn execute_plan(
     use super::classify_tuner::{
         ClassifyTuner, SchedulerKind, TrialSummary, TuneConfig, TuneStrategy,
     };
+    use crate::optim::ParameterValue;
     use crate::transformer::TransformerConfig;
     use std::collections::HashMap;
-    use crate::optim::ParameterValue;
 
     // ── Verify pre-conditions ──────────────────────────────────────────
     if plan.verdict == PlanVerdict::Blocked {
@@ -955,7 +932,10 @@ pub fn execute_plan(
     // exceed RTX 4090 VRAM (24 GB) after scratch + kernel cache overhead.
     let auto_nf4 = model_config.hidden_size >= 2048;
     if auto_nf4 {
-        eprintln!("[plan] Auto-enabling NF4 quantization (hidden_size={} >= 2048)", model_config.hidden_size);
+        eprintln!(
+            "[plan] Auto-enabling NF4 quantization (hidden_size={} >= 2048)",
+            model_config.hidden_size
+        );
     }
 
     // ── Manual strategy: single trial ──────────────────────────────────
@@ -1008,10 +988,7 @@ pub fn execute_plan(
             "learning_rate".to_string(),
             ParameterValue::Float(f64::from(manual.learning_rate)),
         );
-        config_map.insert(
-            "lora_rank".to_string(),
-            ParameterValue::Int(manual.lora_rank as i64),
-        );
+        config_map.insert("lora_rank".to_string(), ParameterValue::Int(manual.lora_rank as i64));
         config_map.insert(
             "batch_size".to_string(),
             ParameterValue::Categorical(manual.batch_size.to_string()),
@@ -1024,10 +1001,7 @@ pub fn execute_plan(
                 .epoch_metrics
                 .get(result.best_epoch)
                 .map_or(0.0, |m| f64::from(m.val_accuracy)),
-            train_loss: result
-                .epoch_metrics
-                .last()
-                .map_or(0.0, |m| f64::from(m.train_loss)),
+            train_loss: result.epoch_metrics.last().map_or(0.0, |m| f64::from(m.train_loss)),
             train_accuracy: result
                 .epoch_metrics
                 .last()
@@ -1059,11 +1033,7 @@ pub fn execute_plan(
     }
 
     // ── HPO strategy: multiple trials ──────────────────────────────────
-    let strategy: TuneStrategy = plan
-        .hyperparameters
-        .strategy
-        .parse()
-        .unwrap_or(TuneStrategy::Tpe);
+    let strategy: TuneStrategy = plan.hyperparameters.strategy.parse().unwrap_or(TuneStrategy::Tpe);
 
     let num_classes = plan.data.class_counts.len();
 
@@ -1102,17 +1072,10 @@ pub fn execute_plan(
             super::classify_tuner::extract_trial_params(&suggestion.config);
 
         // ── Build ClassifyConfig from trial params ─────────────────────
-        let class_weights = resolve_class_weights(
-            &weights_strategy,
-            &plan.data.class_counts,
-            num_classes,
-        );
+        let class_weights =
+            resolve_class_weights(&weights_strategy, &plan.data.class_counts, num_classes);
 
-        let epochs = if plan.hyperparameters.scout {
-            1
-        } else {
-            plan.hyperparameters.max_epochs
-        };
+        let epochs = if plan.hyperparameters.scout { 1 } else { plan.hyperparameters.max_epochs };
 
         let classify_config = ClassifyConfig {
             num_classes,
@@ -1159,11 +1122,7 @@ pub fn execute_plan(
                     .map_or(0.0, |m| f64::from(m.val_accuracy));
 
                 // ── Check scheduler for early stopping ─────────────────
-                let was_pruned = scheduler.should_stop(
-                    trial_idx,
-                    result.best_epoch,
-                    val_loss,
-                );
+                let was_pruned = scheduler.should_stop(trial_idx, result.best_epoch, val_loss);
 
                 let status = resolve_trial_status(was_pruned, result.stopped_early);
 
@@ -1261,8 +1220,7 @@ fn run_single_trial_with_warmup(
     })?;
 
     // Load pipeline with pretrained weights
-    let pipeline =
-        ClassifyPipeline::from_pretrained(model_path, model_config, classify_config)?;
+    let pipeline = ClassifyPipeline::from_pretrained(model_path, model_config, classify_config)?;
 
     // Load corpus
     let samples = pipeline.load_corpus(data_path)?;
@@ -1294,11 +1252,8 @@ fn run_single_trial_with_warmup(
             .map(|d| d.as_secs())
             .unwrap_or(0)
     );
-    let writer = crate::monitor::tui::TrainingStateWriter::new(
-        checkpoint_dir,
-        &experiment_id,
-        model_name,
-    );
+    let writer =
+        crate::monitor::tui::TrainingStateWriter::new(checkpoint_dir, &experiment_id, model_name);
     trainer.set_monitor_writer(writer);
 
     // Run training
@@ -1321,11 +1276,7 @@ fn resolve_class_weights(
                 class_counts: class_counts.to_vec(),
                 avg_input_len: 0,
             };
-            Some(compute_class_weights(
-                &stats,
-                ClassWeightStrategy::InverseFreq,
-                num_classes,
-            ))
+            Some(compute_class_weights(&stats, ClassWeightStrategy::InverseFreq, num_classes))
         }
         "sqrt_inverse" => {
             let stats = SafetyCorpusStats {
@@ -1333,11 +1284,7 @@ fn resolve_class_weights(
                 class_counts: class_counts.to_vec(),
                 avg_input_len: 0,
             };
-            Some(compute_class_weights(
-                &stats,
-                ClassWeightStrategy::SqrtInverse,
-                num_classes,
-            ))
+            Some(compute_class_weights(&stats, ClassWeightStrategy::SqrtInverse, num_classes))
         }
         _ => None,
     }
@@ -1434,7 +1381,8 @@ impl ExperimentTracker {
             Err(_) => return,
         };
         let _ = store.start_run(&run_id);
-        let _ = store.log_param(&run_id, "learning_rate", SPV::Float(f64::from(manual.learning_rate)));
+        let _ =
+            store.log_param(&run_id, "learning_rate", SPV::Float(f64::from(manual.learning_rate)));
         let _ = store.log_param(&run_id, "lora_rank", SPV::Int(manual.lora_rank as i64));
         let _ = store.log_param(&run_id, "batch_size", SPV::Int(manual.batch_size as i64));
         Self::log_epoch_metrics(store, &run_id, &result.epoch_metrics);
@@ -1447,8 +1395,8 @@ impl ExperimentTracker {
         result: &super::classify_trainer::TrainResult,
         was_pruned: bool,
     ) {
-        use crate::storage::{ExperimentStorage, ParameterValue as SPV};
         use crate::optim::ParameterValue as OPV;
+        use crate::storage::{ExperimentStorage, ParameterValue as SPV};
         let (store, eid) = match (self.store.as_mut(), self.exp_id.as_ref()) {
             (Some(s), Some(e)) => (s, e),
             _ => return,
@@ -1496,7 +1444,8 @@ impl ExperimentTracker {
         for (i, epoch) in epochs.iter().enumerate() {
             let _ = store.log_metric(run_id, "train_loss", i as u64, f64::from(epoch.train_loss));
             let _ = store.log_metric(run_id, "val_loss", i as u64, f64::from(epoch.val_loss));
-            let _ = store.log_metric(run_id, "val_accuracy", i as u64, f64::from(epoch.val_accuracy));
+            let _ =
+                store.log_metric(run_id, "val_accuracy", i as u64, f64::from(epoch.val_accuracy));
         }
     }
 }
@@ -1542,10 +1491,7 @@ mod tests {
         let data_path = dir.path().join("train.jsonl");
         let mut lines = Vec::new();
         for i in 0..50 {
-            lines.push(format!(
-                r#"{{"input": "echo test {i}", "label": {}}}"#,
-                i % 5
-            ));
+            lines.push(format!(r#"{{"input": "echo test {i}", "label": {}}}"#, i % 5));
         }
         std::fs::write(&data_path, lines.join("\n")).expect("valid");
 
@@ -1584,10 +1530,7 @@ mod tests {
         let data_path = dir.path().join("train.jsonl");
         let mut lines = Vec::new();
         for i in 0..100 {
-            lines.push(format!(
-                r#"{{"input": "echo test {i}", "label": {}}}"#,
-                i % 5
-            ));
+            lines.push(format!(r#"{{"input": "echo test {i}", "label": {}}}"#, i % 5));
         }
         std::fs::write(&data_path, lines.join("\n")).expect("valid");
 
@@ -1629,15 +1572,11 @@ mod tests {
         let mut lines = Vec::new();
         // 80 class 0, 10 each for classes 1-4 = 8:1 imbalance
         for i in 0..80 {
-            lines.push(format!(
-                r#"{{"input": "safe command {i}", "label": 0}}"#
-            ));
+            lines.push(format!(r#"{{"input": "safe command {i}", "label": 0}}"#));
         }
         for c in 1..5 {
             for i in 0..10 {
-                lines.push(format!(
-                    r#"{{"input": "class {c} cmd {i}", "label": {c}}}"#
-                ));
+                lines.push(format!(r#"{{"input": "class {c} cmd {i}", "label": {c}}}"#));
             }
         }
         std::fs::write(&data_path, lines.join("\n")).expect("valid");
@@ -1677,10 +1616,7 @@ mod tests {
         let data_path = dir.path().join("train.jsonl");
         let mut lines = Vec::new();
         for i in 0..50 {
-            lines.push(format!(
-                r#"{{"input": "echo test {i}", "label": {}}}"#,
-                i % 5
-            ));
+            lines.push(format!(r#"{{"input": "echo test {i}", "label": {}}}"#, i % 5));
         }
         // Add 5 exact duplicates
         for _ in 0..5 {
@@ -1722,10 +1658,7 @@ mod tests {
         let data_path = dir.path().join("train.jsonl");
         let mut lines = Vec::new();
         for i in 0..20 {
-            lines.push(format!(
-                r#"{{"input": "echo {i}", "label": {}}}"#,
-                i % 5
-            ));
+            lines.push(format!(r#"{{"input": "echo {i}", "label": {}}}"#, i % 5));
         }
         std::fs::write(&data_path, lines.join("\n")).expect("valid");
 
@@ -1773,10 +1706,7 @@ mod tests {
         let data_path = dir.path().join("train.jsonl");
         let mut lines = Vec::new();
         for i in 0..100 {
-            lines.push(format!(
-                r#"{{"input": "echo test {i}", "label": {}}}"#,
-                i % 5
-            ));
+            lines.push(format!(r#"{{"input": "echo test {i}", "label": {}}}"#, i % 5));
         }
         std::fs::write(&data_path, lines.join("\n")).expect("valid");
 
@@ -1815,10 +1745,7 @@ mod tests {
         let data_path = dir.path().join("train.jsonl");
         let mut lines = Vec::new();
         for i in 0..100 {
-            lines.push(format!(
-                r#"{{"input": "echo test {i}", "label": {}}}"#,
-                i % 5
-            ));
+            lines.push(format!(r#"{{"input": "echo test {i}", "label": {}}}"#, i % 5));
         }
         std::fs::write(&data_path, lines.join("\n")).expect("valid");
 
@@ -1856,10 +1783,7 @@ mod tests {
         let data_path = dir.path().join("train.jsonl");
         let mut lines = Vec::new();
         for i in 0..20 {
-            lines.push(format!(
-                r#"{{"input": "echo {i}", "label": {}}}"#,
-                i % 5
-            ));
+            lines.push(format!(r#"{{"input": "echo {i}", "label": {}}}"#, i % 5));
         }
         std::fs::write(&data_path, lines.join("\n")).expect("valid");
 
@@ -1975,7 +1899,10 @@ mod tests {
         let w = weights.expect("valid");
         assert_eq!(w.len(), 3);
         // Largest class should have smallest weight
-        assert!(w[0] > w[2], "class 0 (100 samples) should have higher weight than class 2 (300 samples)");
+        assert!(
+            w[0] > w[2],
+            "class 0 (100 samples) should have higher weight than class 2 (300 samples)"
+        );
     }
 
     #[test]

--- a/src/finetune/tune_searchers.rs
+++ b/src/finetune/tune_searchers.rs
@@ -194,11 +194,8 @@ impl TuneScheduler for AshaScheduler {
         }
 
         // Collect all completed trials' val_loss at this epoch
-        let mut losses_at_epoch: Vec<f64> = self
-            .history
-            .iter()
-            .filter_map(|h| h.get(epoch).copied())
-            .collect();
+        let mut losses_at_epoch: Vec<f64> =
+            self.history.iter().filter_map(|h| h.get(epoch).copied()).collect();
 
         if losses_at_epoch.is_empty() {
             return false;
@@ -208,8 +205,7 @@ impl TuneScheduler for AshaScheduler {
 
         // Keep top 1/eta — prune if val_loss is above the cutoff
         let keep_fraction = 1.0 / self.reduction_factor;
-        let cutoff_idx =
-            ((losses_at_epoch.len() as f64 * keep_fraction).ceil() as usize).max(1);
+        let cutoff_idx = ((losses_at_epoch.len() as f64 * keep_fraction).ceil() as usize).max(1);
         if cutoff_idx >= losses_at_epoch.len() {
             return false;
         }
@@ -247,11 +243,8 @@ impl TuneScheduler for MedianScheduler {
             return false;
         }
 
-        let mut losses: Vec<f64> = self
-            .history
-            .iter()
-            .filter_map(|h| h.get(epoch).copied())
-            .collect();
+        let mut losses: Vec<f64> =
+            self.history.iter().filter_map(|h| h.get(epoch).copied()).collect();
 
         if losses.len() < 2 {
             return false;

--- a/src/finetune/worker_client.rs
+++ b/src/finetune/worker_client.rs
@@ -92,20 +92,12 @@ impl WorkerClient {
         // Read JoinAccepted
         let response = read_wire_message(&stream)?;
         match response {
-            WireMessage::JoinAccepted {
-                worker_id,
-                total_workers,
-            } => {
+            WireMessage::JoinAccepted { worker_id, total_workers } => {
                 eprintln!(
                     "[worker {}] Joined as worker {worker_id}/{total_workers}",
                     config.node_id
                 );
-                Ok(Self {
-                    config,
-                    stream,
-                    worker_id,
-                    total_workers,
-                })
+                Ok(Self { config, stream, worker_id, total_workers })
             }
             other => Err(format!("expected JoinAccepted, got {other:?}")),
         }
@@ -120,20 +112,11 @@ impl WorkerClient {
     pub fn receive_shard(&self) -> Result<Option<ShardAssignment>, String> {
         let msg = read_wire_message(&self.stream)?;
         match msg {
-            WireMessage::ShardAssignment {
-                step,
-                shard_start,
-                shard_end,
-            } => Ok(Some(ShardAssignment {
-                step,
-                shard_start,
-                shard_end,
-            })),
+            WireMessage::ShardAssignment { step, shard_start, shard_end } => {
+                Ok(Some(ShardAssignment { step, shard_start, shard_end }))
+            }
             WireMessage::Shutdown => {
-                eprintln!(
-                    "[worker {}] Received shutdown from coordinator",
-                    self.config.node_id
-                );
+                eprintln!("[worker {}] Received shutdown from coordinator", self.config.node_id);
                 Ok(None)
             }
             other => Err(format!("expected ShardAssignment or Shutdown, got {other:?}")),
@@ -177,15 +160,9 @@ impl WorkerClient {
     pub fn receive_averaged(&self) -> Result<AveragedResult, String> {
         let msg = read_wire_message(&self.stream)?;
         match msg {
-            WireMessage::AveragedGradient {
-                step,
-                gradients,
-                global_loss,
-            } => Ok(AveragedResult {
-                step,
-                gradients,
-                global_loss,
-            }),
+            WireMessage::AveragedGradient { step, gradients, global_loss } => {
+                Ok(AveragedResult { step, gradients, global_loss })
+            }
             WireMessage::Shutdown => Err("shutdown during AllReduce".to_string()),
             other => Err(format!("expected AveragedGradient, got {other:?}")),
         }
@@ -224,17 +201,9 @@ impl WorkerClient {
     pub fn receive_averaged_block(&self) -> Result<AveragedBlockResult, String> {
         let msg = read_wire_message(&self.stream)?;
         match msg {
-            WireMessage::AveragedBlockGradient {
-                step,
-                block_idx,
-                gradients,
-                component_sizes,
-            } => Ok(AveragedBlockResult {
-                step,
-                block_idx,
-                gradients,
-                component_sizes,
-            }),
+            WireMessage::AveragedBlockGradient { step, block_idx, gradients, component_sizes } => {
+                Ok(AveragedBlockResult { step, block_idx, gradients, component_sizes })
+            }
             WireMessage::Shutdown => Err("shutdown during block AllReduce".to_string()),
             other => Err(format!("expected AveragedBlockGradient, got {other:?}")),
         }
@@ -265,15 +234,9 @@ impl WorkerClient {
     pub fn receive_averaged_non_block(&self) -> Result<AveragedNonBlockResult, String> {
         let msg = read_wire_message(&self.stream)?;
         match msg {
-            WireMessage::AveragedNonBlockGradient {
-                step,
-                component,
-                gradients,
-            } => Ok(AveragedNonBlockResult {
-                step,
-                component,
-                gradients,
-            }),
+            WireMessage::AveragedNonBlockGradient { step, component, gradients } => {
+                Ok(AveragedNonBlockResult { step, component, gradients })
+            }
             WireMessage::Shutdown => Err("shutdown during non-block AllReduce".to_string()),
             other => Err(format!("expected AveragedNonBlockGradient, got {other:?}")),
         }
@@ -295,14 +258,15 @@ impl WorkerClient {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
-    use super::*;
     use super::super::distributed::DistributedConfig;
     use super::super::gradient_server::GradientServer;
+    use super::*;
     use std::thread;
 
     #[test]
     fn test_worker_connect_and_join() {
-        let server_config = DistributedConfig::coordinator("127.0.0.1:0".parse().expect("valid"), 1);
+        let server_config =
+            DistributedConfig::coordinator("127.0.0.1:0".parse().expect("valid"), 1);
         let mut server = GradientServer::bind(server_config).expect("valid");
         let addr = server.local_addr();
 
@@ -320,7 +284,8 @@ mod tests {
 
     #[test]
     fn test_worker_block_gradient_roundtrip() {
-        let server_config = DistributedConfig::coordinator("127.0.0.1:0".parse().expect("valid"), 1);
+        let server_config =
+            DistributedConfig::coordinator("127.0.0.1:0".parse().expect("valid"), 1);
         let mut server = GradientServer::bind(server_config).expect("valid");
         let addr = server.local_addr();
 
@@ -361,7 +326,8 @@ mod tests {
 
     #[test]
     fn test_worker_non_block_gradient_roundtrip() {
-        let server_config = DistributedConfig::coordinator("127.0.0.1:0".parse().expect("valid"), 1);
+        let server_config =
+            DistributedConfig::coordinator("127.0.0.1:0".parse().expect("valid"), 1);
         let mut server = GradientServer::bind(server_config).expect("valid");
         let addr = server.local_addr();
 
@@ -395,7 +361,8 @@ mod tests {
 
     #[test]
     fn test_two_worker_block_allreduce() {
-        let server_config = DistributedConfig::coordinator("127.0.0.1:0".parse().expect("valid"), 2);
+        let server_config =
+            DistributedConfig::coordinator("127.0.0.1:0".parse().expect("valid"), 2);
         let mut server = GradientServer::bind(server_config).expect("valid");
         let addr = server.local_addr();
 
@@ -440,7 +407,8 @@ mod tests {
 
     #[test]
     fn test_worker_full_training_step() {
-        let server_config = DistributedConfig::coordinator("127.0.0.1:0".parse().expect("valid"), 1);
+        let server_config =
+            DistributedConfig::coordinator("127.0.0.1:0".parse().expect("valid"), 1);
         let mut server = GradientServer::bind(server_config).expect("valid");
         let addr = server.local_addr();
 
@@ -455,9 +423,7 @@ mod tests {
             assert_eq!(shard.shard_end, 50);
 
             // Send gradients
-            client
-                .send_gradients(0, vec![1.0, 2.0, 3.0], 0.5, 48, 50)
-                .expect("valid");
+            client.send_gradients(0, vec![1.0, 2.0, 3.0], 0.5, 48, 50).expect("valid");
 
             // Receive averaged
             let avg = client.receive_averaged().expect("valid");

--- a/src/gpu/cluster.rs
+++ b/src/gpu/cluster.rs
@@ -67,7 +67,6 @@ pub enum Transport {
     Ssh,
 }
 
-
 /// Configuration for a single GPU on a node.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GpuConfig {
@@ -94,7 +93,6 @@ pub enum MemoryType {
     /// Unified memory shared with CPU (60% reserve factor).
     Unified,
 }
-
 
 impl MemoryType {
     /// Reserve factor: fraction of VRAM usable for training.
@@ -162,21 +160,15 @@ impl ClusterConfig {
         let mut names = HashSet::new();
         for node in &self.nodes {
             if !names.insert(&node.name) {
-                return Err(ClusterValidationError::DuplicateNodeName(
-                    node.name.clone(),
-                ));
+                return Err(ClusterValidationError::DuplicateNodeName(node.name.clone()));
             }
             if node.max_adapters == 0 {
-                return Err(ClusterValidationError::ZeroMaxAdapters {
-                    name: node.name.clone(),
-                });
+                return Err(ClusterValidationError::ZeroMaxAdapters { name: node.name.clone() });
             }
             if node.transport == Transport::Ssh
                 && (node.host == "localhost" || node.host == "127.0.0.1")
             {
-                return Err(ClusterValidationError::SshLocalhost {
-                    node: node.name.clone(),
-                });
+                return Err(ClusterValidationError::SshLocalhost { node: node.name.clone() });
             }
             validate_node_gpus(node)?;
         }
@@ -254,16 +246,19 @@ impl GpuConfig {
 
 impl std::fmt::Display for ClusterConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Cluster: {} node(s), {} adapter slots",
-            self.nodes.len(), self.total_adapter_capacity())?;
+        writeln!(
+            f,
+            "Cluster: {} node(s), {} adapter slots",
+            self.nodes.len(),
+            self.total_adapter_capacity()
+        )?;
         for node in &self.nodes {
             write!(f, "  {}: {} ({})", node.name, node.host, node.transport)?;
             if node.gpus.is_empty() {
                 write!(f, " [CPU-only]")?;
             } else {
                 for gpu in &node.gpus {
-                    write!(f, " [{} {} MB {:?}]",
-                        gpu.gpu_type, gpu.vram_mb, gpu.memory_type)?;
+                    write!(f, " [{} {} MB {:?}]", gpu.gpu_type, gpu.vram_mb, gpu.memory_type)?;
                 }
             }
             writeln!(f, " max_adapters={}", node.max_adapters)?;
@@ -530,9 +525,9 @@ pub struct GpuCostModel {
 impl Default for GpuCostModel {
     fn default() -> Self {
         Self {
-            pcie_cost_per_mb: 40.0,       // PCIe 4.0 ~25 GB/s → ~40 µs/MB
-            gpu_compute_per_mflop: 0.01,  // RTX 4090 ~80 TFLOPS → ~0.01 µs/MFLOP
-            dispatch_threshold: 5.0,      // 5× PCIe rule
+            pcie_cost_per_mb: 40.0,      // PCIe 4.0 ~25 GB/s → ~40 µs/MB
+            gpu_compute_per_mflop: 0.01, // RTX 4090 ~80 TFLOPS → ~0.01 µs/MFLOP
+            dispatch_threshold: 5.0,     // 5× PCIe rule
         }
     }
 }

--- a/src/gpu/coordinator.rs
+++ b/src/gpu/coordinator.rs
@@ -84,11 +84,7 @@ impl CheckpointCoordinator {
                 },
             );
         }
-        Self {
-            adapters,
-            poll_interval_secs,
-            cluster,
-        }
+        Self { adapters, poll_interval_secs, cluster }
     }
 
     /// Poll all adapters for their latest checkpoint metadata.
@@ -133,16 +129,9 @@ impl CheckpointCoordinator {
                 if let Some(status) = self.adapters.get_mut(&adapter_idx) {
                     status.latest = Some(meta.clone());
                 }
-                PollResult::Ok {
-                    adapter_idx,
-                    metadata: meta,
-                }
+                PollResult::Ok { adapter_idx, metadata: meta }
             }
-            Err(e) => PollResult::Error {
-                adapter_idx,
-                node_name: node_name.to_string(),
-                error: e,
-            },
+            Err(e) => PollResult::Error { adapter_idx, node_name: node_name.to_string(), error: e },
         }
     }
 
@@ -172,9 +161,7 @@ impl CheckpointCoordinator {
     /// Find the best adapter (lowest loss).
     pub fn best_adapter(&self) -> Option<&AdapterStatus> {
         let board = self.leaderboard();
-        board
-            .first()
-            .and_then(|entry| self.adapters.get(&entry.adapter_idx))
+        board.first().and_then(|entry| self.adapters.get(&entry.adapter_idx))
     }
 
     /// Format leaderboard as a human-readable string.
@@ -199,15 +186,8 @@ impl CheckpointCoordinator {
 /// Result of polling a single adapter's checkpoint.
 #[derive(Debug)]
 pub enum PollResult {
-    Ok {
-        adapter_idx: usize,
-        metadata: CheckpointMetadata,
-    },
-    Error {
-        adapter_idx: usize,
-        node_name: String,
-        error: String,
-    },
+    Ok { adapter_idx: usize, metadata: CheckpointMetadata },
+    Error { adapter_idx: usize, node_name: String, error: String },
 }
 
 /// Read checkpoint metadata from a local path.
@@ -223,12 +203,15 @@ fn read_local_metadata(checkpoint_dir: &Path) -> Result<CheckpointMetadata, Stri
 ///
 /// Executes `ssh [-l user] host cat <checkpoint_dir>/best/metadata.json`
 /// and parses the JSON output. Timeout: 10 seconds.
-fn read_ssh_metadata(host: &str, user: Option<&str>, checkpoint_dir: &Path) -> Result<CheckpointMetadata, String> {
+fn read_ssh_metadata(
+    host: &str,
+    user: Option<&str>,
+    checkpoint_dir: &Path,
+) -> Result<CheckpointMetadata, String> {
     let remote_path = checkpoint_dir.join("best").join("metadata.json");
     let cat_cmd = format!("cat {}", remote_path.display());
     let output = exec_ssh_command(host, user, &cat_cmd)?;
-    serde_json::from_str(&output)
-        .map_err(|e| format!("failed to parse metadata from {host}: {e}"))
+    serde_json::from_str(&output).map_err(|e| format!("failed to parse metadata from {host}: {e}"))
 }
 
 /// Execute a command on a remote host via SSH.
@@ -253,9 +236,7 @@ fn exec_ssh_command(host: &str, user: Option<&str>, script: &str) -> Result<Stri
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
 
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| format!("failed to spawn ssh to {host}: {e}"))?;
+    let mut child = cmd.spawn().map_err(|e| format!("failed to spawn ssh to {host}: {e}"))?;
 
     // Pipe script via stdin (safe against injection)
     if let Some(stdin) = child.stdin.take() {
@@ -265,9 +246,7 @@ fn exec_ssh_command(host: &str, user: Option<&str>, script: &str) -> Result<Stri
         // stdin is dropped here, sending EOF
     }
 
-    let output = child
-        .wait_with_output()
-        .map_err(|e| format!("ssh to {host} failed: {e}"))?;
+    let output = child.wait_with_output().map_err(|e| format!("ssh to {host} failed: {e}"))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -277,8 +256,7 @@ fn exec_ssh_command(host: &str, user: Option<&str>, script: &str) -> Result<Stri
         ));
     }
 
-    String::from_utf8(output.stdout)
-        .map_err(|e| format!("invalid UTF-8 from ssh to {host}: {e}"))
+    String::from_utf8(output.stdout).map_err(|e| format!("invalid UTF-8 from ssh to {host}: {e}"))
 }
 
 /// Execute a training job on a remote or local node.
@@ -304,16 +282,14 @@ pub fn exec_launch(
     );
 
     match node.transport {
-        Transport::Local => {
-            std::process::Command::new("bash")
-                .arg("-c")
-                .arg(&script)
-                .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .spawn()
-                .map_err(|e| format!("failed to launch local training: {e}"))
-        }
+        Transport::Local => std::process::Command::new("bash")
+            .arg("-c")
+            .arg(&script)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("failed to launch local training: {e}")),
         Transport::Ssh => {
             let mut cmd = std::process::Command::new("ssh");
             cmd.args(["-o", "ConnectTimeout=5"]);
@@ -328,9 +304,8 @@ pub fn exec_launch(
             cmd.stdout(std::process::Stdio::piped());
             cmd.stderr(std::process::Stdio::piped());
 
-            let mut child = cmd
-                .spawn()
-                .map_err(|e| format!("failed to ssh to {}: {e}", node.host))?;
+            let mut child =
+                cmd.spawn().map_err(|e| format!("failed to ssh to {}: {e}", node.host))?;
 
             if let Some(stdin) = child.stdin.take() {
                 use std::io::Write;
@@ -366,10 +341,7 @@ pub fn build_launch_command(
     match node.transport {
         Transport::Local => base,
         Transport::Ssh => {
-            let user_prefix = node
-                .user
-                .as_ref()
-                .map_or_else(String::new, |u| format!("{u}@"));
+            let user_prefix = node.user.as_ref().map_or_else(String::new, |u| format!("{u}@"));
             format!("ssh {user_prefix}{} '{base}'", node.host)
         }
     }
@@ -393,27 +365,20 @@ pub struct NodeHealth {
 /// For local nodes, checks that `apr --version` is available.
 /// For SSH nodes, runs `ssh host 'apr --version'` with timeout.
 pub fn check_cluster_health(cluster: &ClusterConfig) -> Vec<NodeHealth> {
-    cluster
-        .nodes
-        .iter()
-        .map(|node| check_node_health(node))
-        .collect()
+    cluster.nodes.iter().map(|node| check_node_health(node)).collect()
 }
 
 fn check_node_health(node: &NodeConfig) -> NodeHealth {
     let script = "apr --version 2>/dev/null || echo 'apr: not found'";
     let result = match node.transport {
-        Transport::Local => {
-            std::process::Command::new("bash")
-                .arg("-c")
-                .arg(script)
-                .output()
-                .map_err(|e| format!("failed to check local health: {e}"))
-                .and_then(|out| {
-                    String::from_utf8(out.stdout)
-                        .map_err(|e| format!("invalid UTF-8: {e}"))
-                })
-        }
+        Transport::Local => std::process::Command::new("bash")
+            .arg("-c")
+            .arg(script)
+            .output()
+            .map_err(|e| format!("failed to check local health: {e}"))
+            .and_then(|out| {
+                String::from_utf8(out.stdout).map_err(|e| format!("invalid UTF-8: {e}"))
+            }),
         Transport::Ssh => exec_ssh_command(&node.host, node.user.as_deref(), script),
     };
 
@@ -425,11 +390,7 @@ fn check_node_health(node: &NodeConfig) -> NodeHealth {
                 node_name: node.name.clone(),
                 reachable: true,
                 apr_version: if has_apr { Some(trimmed) } else { None },
-                error: if has_apr {
-                    None
-                } else {
-                    Some("apr CLI not found on node".to_string())
-                },
+                error: if has_apr { None } else { Some("apr CLI not found on node".to_string()) },
             }
         }
         Err(e) => NodeHealth {
@@ -449,9 +410,8 @@ impl CheckpointCoordinator {
     ///
     /// Returns the local path where the checkpoint was saved.
     pub fn pull_best_checkpoint(&self, dest: &Path) -> Result<PathBuf, String> {
-        let best = self
-            .best_adapter()
-            .ok_or_else(|| "no adapters with checkpoint data".to_string())?;
+        let best =
+            self.best_adapter().ok_or_else(|| "no adapters with checkpoint data".to_string())?;
 
         let node = self
             .cluster
@@ -469,15 +429,8 @@ impl CheckpointCoordinator {
             Transport::Ssh => {
                 std::fs::create_dir_all(&dest_dir)
                     .map_err(|e| format!("failed to create {}: {e}", dest_dir.display()))?;
-                let user_prefix = node
-                    .user
-                    .as_ref()
-                    .map_or_else(String::new, |u| format!("{u}@"));
-                let remote = format!(
-                    "{user_prefix}{}:{}/",
-                    node.host,
-                    source_dir.display()
-                );
+                let user_prefix = node.user.as_ref().map_or_else(String::new, |u| format!("{u}@"));
+                let remote = format!("{user_prefix}{}:{}/", node.host, source_dir.display());
                 let output = std::process::Command::new("scp")
                     .args(["-r", "-o", "ConnectTimeout=10", "-o", "BatchMode=yes"])
                     .arg(&remote)
@@ -497,10 +450,9 @@ impl CheckpointCoordinator {
 
 /// Recursively copy a directory tree.
 fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), String> {
-    std::fs::create_dir_all(dst)
-        .map_err(|e| format!("failed to create {}: {e}", dst.display()))?;
-    let entries = std::fs::read_dir(src)
-        .map_err(|e| format!("failed to read {}: {e}", src.display()))?;
+    std::fs::create_dir_all(dst).map_err(|e| format!("failed to create {}: {e}", dst.display()))?;
+    let entries =
+        std::fs::read_dir(src).map_err(|e| format!("failed to read {}: {e}", src.display()))?;
     for entry in entries {
         let entry = entry.map_err(|e| format!("failed to read entry: {e}"))?;
         let dest_path = dst.join(entry.file_name());
@@ -547,21 +499,9 @@ nodes:
 
     fn test_placements() -> Vec<PlacementDecision> {
         vec![
-            PlacementDecision {
-                adapter_idx: 0,
-                node_name: "desktop".to_string(),
-                score: 2.5,
-            },
-            PlacementDecision {
-                adapter_idx: 1,
-                node_name: "desktop".to_string(),
-                score: 1.2,
-            },
-            PlacementDecision {
-                adapter_idx: 2,
-                node_name: "jetson".to_string(),
-                score: 0.3,
-            },
+            PlacementDecision { adapter_idx: 0, node_name: "desktop".to_string(), score: 2.5 },
+            PlacementDecision { adapter_idx: 1, node_name: "desktop".to_string(), score: 1.2 },
+            PlacementDecision { adapter_idx: 2, node_name: "jetson".to_string(), score: 0.3 },
         ]
     }
 
@@ -640,11 +580,8 @@ nodes:
             node_name: Some("desktop".to_string()),
             timestamp: None,
         };
-        fs::write(
-            best_dir.join("metadata.json"),
-            serde_json::to_string(&meta).expect("valid"),
-        )
-        .expect("valid");
+        fs::write(best_dir.join("metadata.json"), serde_json::to_string(&meta).expect("valid"))
+            .expect("valid");
 
         let cluster = test_cluster();
         let placements = vec![PlacementDecision {
@@ -660,10 +597,7 @@ nodes:
 
         assert_eq!(results.len(), 1);
         match &results[0] {
-            PollResult::Ok {
-                adapter_idx,
-                metadata,
-            } => {
+            PollResult::Ok { adapter_idx, metadata } => {
                 assert_eq!(*adapter_idx, 0);
                 assert_eq!(metadata.epoch, 5);
                 assert!((metadata.avg_loss - 0.42).abs() < f32::EPSILON);
@@ -676,13 +610,9 @@ nodes:
     fn test_poll_ssh_attempts_real_ssh() {
         // SSH poll now attempts real SSH (will fail on missing host, not with stub error)
         let cluster = test_cluster();
-        let placements = vec![PlacementDecision {
-            adapter_idx: 2,
-            node_name: "jetson".to_string(),
-            score: 0.3,
-        }];
-        let mut coord =
-            CheckpointCoordinator::new(cluster, &placements, &HashMap::new(), 300);
+        let placements =
+            vec![PlacementDecision { adapter_idx: 2, node_name: "jetson".to_string(), score: 0.3 }];
+        let mut coord = CheckpointCoordinator::new(cluster, &placements, &HashMap::new(), 300);
         let results = coord.poll_all();
 
         assert_eq!(results.len(), 1);
@@ -709,9 +639,13 @@ nodes:
         let err = result.unwrap_err();
         // Should be a real SSH/network error
         assert!(
-            err.contains("ssh") || err.contains("Connection") || err.contains("timed out")
-                || err.contains("refused") || err.contains("resolve")
-                || err.contains("No route") || err.contains("exited"),
+            err.contains("ssh")
+                || err.contains("Connection")
+                || err.contains("timed out")
+                || err.contains("refused")
+                || err.contains("resolve")
+                || err.contains("No route")
+                || err.contains("exited"),
             "expected real SSH error, got: {err}"
         );
     }
@@ -865,11 +799,8 @@ nodes:
             node_name: Some("desktop".to_string()),
             timestamp: None,
         };
-        fs::write(
-            best_dir.join("metadata.json"),
-            serde_json::to_string(&meta).expect("valid"),
-        )
-        .expect("valid");
+        fs::write(best_dir.join("metadata.json"), serde_json::to_string(&meta).expect("valid"))
+            .expect("valid");
         fs::write(best_dir.join("adapter.safetensors"), b"fake-weights").expect("valid");
 
         let cluster = test_cluster();
@@ -897,8 +828,7 @@ nodes:
     #[test]
     fn test_pull_no_checkpoints_fails() {
         let cluster = test_cluster();
-        let coord =
-            CheckpointCoordinator::new(cluster, &test_placements(), &HashMap::new(), 300);
+        let coord = CheckpointCoordinator::new(cluster, &test_placements(), &HashMap::new(), 300);
         let dest = tempfile::tempdir().expect("valid");
         let result = coord.pull_best_checkpoint(dest.path());
         assert!(result.is_err());

--- a/src/gpu/error.rs
+++ b/src/gpu/error.rs
@@ -13,10 +13,7 @@ pub enum GpuError {
         total_mb: usize,
     },
     /// Wait-for-VRAM timed out.
-    Timeout {
-        budget_mb: usize,
-        timeout_secs: u64,
-    },
+    Timeout { budget_mb: usize, timeout_secs: u64 },
     /// Ledger file is corrupt or unreadable.
     LedgerCorrupt(String),
     /// I/O error accessing ledger.

--- a/src/gpu/guard.rs
+++ b/src/gpu/guard.rs
@@ -34,23 +34,15 @@ impl VramGuard {
     /// Checks the ledger and reserves `budget_mb` of VRAM.
     /// Returns `GpuError::InsufficientMemory` if not enough VRAM available.
     pub fn acquire(budget_mb: usize, task: &str) -> Result<Self, GpuError> {
-        TRACER.span(
-            TraceStep::VramQuery,
-            format!("guard_acquire budget={budget_mb}MB"),
-            || {
-                let mut ledger = super::ledger::auto_ledger();
-                ledger.try_reserve(budget_mb, task)?;
-                Ok(Self { ledger, budget_mb })
-            },
-        )
+        TRACER.span(TraceStep::VramQuery, format!("guard_acquire budget={budget_mb}MB"), || {
+            let mut ledger = super::ledger::auto_ledger();
+            ledger.try_reserve(budget_mb, task)?;
+            Ok(Self { ledger, budget_mb })
+        })
     }
 
     /// Acquire with waiting: poll until VRAM is available or timeout.
-    pub fn acquire_wait(
-        budget_mb: usize,
-        task: &str,
-        timeout_secs: u64,
-    ) -> Result<Self, GpuError> {
+    pub fn acquire_wait(budget_mb: usize, task: &str, timeout_secs: u64) -> Result<Self, GpuError> {
         TRACER.span(
             TraceStep::WaitPoll,
             format!("guard_wait budget={budget_mb}MB timeout={timeout_secs}s"),
@@ -91,7 +83,7 @@ impl VramGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     use std::sync::atomic::{AtomicU32, Ordering};
 
     static TEST_COUNTER: AtomicU32 = AtomicU32::new(0);

--- a/src/gpu/ledger.rs
+++ b/src/gpu/ledger.rs
@@ -253,16 +253,12 @@ impl VramLedger {
             return Ok(());
         };
 
-        TRACER.span(
-            TraceStep::LedgerRelease,
-            format!("ledger_release id={our_id}"),
-            || {
-                self.with_lock_write(|data| {
-                    data.reservations.retain(|r| r.id != our_id);
-                    Ok(())
-                })
-            },
-        )
+        TRACER.span(TraceStep::LedgerRelease, format!("ledger_release id={our_id}"), || {
+            self.with_lock_write(|data| {
+                data.reservations.retain(|r| r.id != our_id);
+                Ok(())
+            })
+        })
     }
 
     /// Read all reservations for our GPU (pruned).
@@ -305,8 +301,7 @@ impl VramLedger {
         let result = f(&data);
 
         #[allow(clippy::incompatible_msrv)]
-        file.unlock()
-            .map_err(|e| GpuError::Io(std::io::Error::other(format!("funlock: {e}"))))?;
+        file.unlock().map_err(|e| GpuError::Io(std::io::Error::other(format!("funlock: {e}"))))?;
 
         Ok(result)
     }
@@ -346,8 +341,7 @@ impl VramLedger {
         // Phase: lock_rel
         self.profiler.begin(GpuProfiler::LOCK_REL);
         #[allow(clippy::incompatible_msrv)]
-        file.unlock()
-            .map_err(|e| GpuError::Io(std::io::Error::other(format!("funlock: {e}"))))?;
+        file.unlock().map_err(|e| GpuError::Io(std::io::Error::other(format!("funlock: {e}"))))?;
         self.profiler.end(GpuProfiler::LOCK_REL);
 
         Ok(result)
@@ -379,8 +373,7 @@ fn read_ledger(file: &File) -> Result<LedgerData, GpuError> {
     if reader.read_to_string(&mut contents).is_err() || contents.trim().is_empty() {
         return Ok(LedgerData::default());
     }
-    serde_json::from_str(&contents)
-        .map_err(|e| GpuError::LedgerCorrupt(format!("JSON parse: {e}")))
+    serde_json::from_str(&contents).map_err(|e| GpuError::LedgerCorrupt(format!("JSON parse: {e}")))
 }
 
 /// Atomic write: write to temp file, fsync, rename over ledger.
@@ -482,10 +475,7 @@ pub fn auto_ledger() -> VramLedger {
 /// Human-readable GPU status display.
 pub fn gpu_status_display(ledger: &VramLedger) -> Result<String, GpuError> {
     let reservations = ledger.read_reservations()?;
-    let reserved: usize = reservations
-        .iter()
-        .map(|r| r.actual_mb.unwrap_or(r.budget_mb))
-        .sum();
+    let reserved: usize = reservations.iter().map(|r| r.actual_mb.unwrap_or(r.budget_mb)).sum();
 
     let mut out = String::new();
     out.push_str(&format!(
@@ -507,7 +497,8 @@ pub fn gpu_status_display(ledger: &VramLedger) -> Result<String, GpuError> {
         out.push_str(&format!("  Reservations: {}\n", reservations.len()));
         for r in &reservations {
             let actual = r
-                .actual_mb.map_or_else(|| "measuring...".to_string(), |a| format!("{a} MB actual"));
+                .actual_mb
+                .map_or_else(|| "measuring...".to_string(), |a| format!("{a} MB actual"));
             let elapsed = Utc::now().signed_duration_since(r.started);
             let hours = elapsed.num_hours();
             let mins = elapsed.num_minutes() % 60;
@@ -544,8 +535,7 @@ mod tests {
     #[test]
     fn test_empty_ledger_has_full_capacity() {
         let path = test_ledger_path();
-        let ledger =
-            VramLedger::new("GPU-test".into(), 24000, 0.85).with_path(path.clone());
+        let ledger = VramLedger::new("GPU-test".into(), 24000, 0.85).with_path(path.clone());
 
         assert_eq!(ledger.capacity_mb(), 20400);
         assert_eq!(ledger.total_reserved().expect("should succeed"), 0);
@@ -557,8 +547,7 @@ mod tests {
     #[test]
     fn test_reserve_and_release() {
         let path = test_ledger_path();
-        let mut ledger =
-            VramLedger::new("GPU-test".into(), 24000, 0.85).with_path(path.clone());
+        let mut ledger = VramLedger::new("GPU-test".into(), 24000, 0.85).with_path(path.clone());
 
         let id = ledger.try_reserve(8000, "test-job").expect("should succeed");
         assert!(id != 0);
@@ -574,19 +563,14 @@ mod tests {
     #[test]
     fn test_capacity_invariant_prevents_overallocation() {
         let path = test_ledger_path();
-        let mut ledger =
-            VramLedger::new("GPU-test".into(), 24000, 0.85).with_path(path.clone());
+        let mut ledger = VramLedger::new("GPU-test".into(), 24000, 0.85).with_path(path.clone());
 
         ledger.try_reserve(15000, "job-1").expect("should succeed");
 
         let result = ledger.try_reserve(10000, "job-2");
         assert!(result.is_err());
         match result.expect_err("should be InsufficientMemory") {
-            GpuError::InsufficientMemory {
-                budget_mb,
-                available_mb,
-                ..
-            } => {
+            GpuError::InsufficientMemory { budget_mb, available_mb, .. } => {
                 assert_eq!(budget_mb, 10000);
                 assert_eq!(available_mb, 5400);
             }
@@ -599,8 +583,7 @@ mod tests {
     #[test]
     fn test_reserve_factor_limits_total() {
         let path = test_ledger_path();
-        let mut ledger =
-            VramLedger::new("GPU-test".into(), 10000, 0.85).with_path(path.clone());
+        let mut ledger = VramLedger::new("GPU-test".into(), 10000, 0.85).with_path(path.clone());
 
         let result = ledger.try_reserve(9000, "too-big");
         assert!(result.is_err());
@@ -611,8 +594,7 @@ mod tests {
     #[test]
     fn test_update_actual() {
         let path = test_ledger_path();
-        let mut ledger =
-            VramLedger::new("GPU-test".into(), 24000, 0.85).with_path(path.clone());
+        let mut ledger = VramLedger::new("GPU-test".into(), 24000, 0.85).with_path(path.clone());
 
         ledger.try_reserve(8000, "test-job").expect("should succeed");
         ledger.update_actual(7300).expect("should succeed");
@@ -629,9 +611,7 @@ mod tests {
             .with_path(path.clone())
             .with_lease_hours(0);
 
-        ledger
-            .try_reserve(8000, "expiring-job")
-            .expect("should succeed");
+        ledger.try_reserve(8000, "expiring-job").expect("should succeed");
 
         std::thread::sleep(Duration::from_millis(10));
 
@@ -643,14 +623,12 @@ mod tests {
     #[test]
     fn test_atomic_write_produces_valid_json() {
         let path = test_ledger_path();
-        let mut ledger =
-            VramLedger::new("GPU-test".into(), 24000, 0.85).with_path(path.clone());
+        let mut ledger = VramLedger::new("GPU-test".into(), 24000, 0.85).with_path(path.clone());
 
         ledger.try_reserve(5000, "json-test").expect("should succeed");
 
         let contents = fs::read_to_string(&path).expect("should read");
-        let data: LedgerData =
-            serde_json::from_str(&contents).expect("should parse");
+        let data: LedgerData = serde_json::from_str(&contents).expect("should parse");
         assert_eq!(data.reservations.len(), 1);
         assert_eq!(data.reservations[0].budget_mb, 5000);
 
@@ -660,12 +638,10 @@ mod tests {
     #[test]
     fn test_gpu_status_display() {
         let path = test_ledger_path();
-        let mut ledger = VramLedger::new("GPU-test-display".into(), 24000, 0.85)
-            .with_path(path.clone());
+        let mut ledger =
+            VramLedger::new("GPU-test-display".into(), 24000, 0.85).with_path(path.clone());
 
-        ledger
-            .try_reserve(7000, "display-test")
-            .expect("should succeed");
+        ledger.try_reserve(7000, "display-test").expect("should succeed");
 
         let status = gpu_status_display(&ledger).expect("should succeed");
         assert!(status.contains("GPU-test-display"));
@@ -701,8 +677,7 @@ mod tests {
     #[test]
     fn test_profiling_disabled_by_default() {
         let path = test_ledger_path();
-        let ledger =
-            VramLedger::new("GPU-test".into(), 24000, 0.85).with_path(path.clone());
+        let ledger = VramLedger::new("GPU-test".into(), 24000, 0.85).with_path(path.clone());
 
         assert!(!ledger.profiler.is_enabled());
         let report = ledger.profiler_report();
@@ -718,9 +693,7 @@ mod tests {
             .with_path(path.clone())
             .with_profiling(true);
 
-        ledger
-            .try_reserve(5000, "profiled-job")
-            .expect("should succeed");
+        ledger.try_reserve(5000, "profiled-job").expect("should succeed");
 
         let report = ledger.profiler_report();
         assert!(report.contains("lock_acq"));

--- a/src/gpu/mps.rs
+++ b/src/gpu/mps.rs
@@ -28,11 +28,7 @@ pub struct MpsConfig {
 
 impl Default for MpsConfig {
     fn default() -> Self {
-        Self {
-            thread_percentage: 50,
-            pinned_mem_limit_mb: None,
-            checkpoint_every_steps: 100,
-        }
+        Self { thread_percentage: 50, pinned_mem_limit_mb: None, checkpoint_every_steps: 100 }
     }
 }
 
@@ -44,10 +40,7 @@ impl MpsConfig {
     #[must_use]
     pub fn with_share(thread_pct: u32) -> Self {
         assert!(thread_pct > 0 && thread_pct <= 100, "thread_pct must be 1-100");
-        Self {
-            thread_percentage: thread_pct,
-            ..Default::default()
-        }
+        Self { thread_percentage: thread_pct, ..Default::default() }
     }
 
     /// Set pinned device memory limit (MB) to prevent OOM cascades.
@@ -94,7 +87,10 @@ pub fn print_mps_warning(config: &MpsConfig) {
     if let Some(limit) = config.pinned_mem_limit_mb {
         eprintln!("  Pinned memory limit: {limit} MB");
     }
-    eprintln!("  Checkpoint frequency: every {} steps (blast radius limit)", config.checkpoint_every_steps);
+    eprintln!(
+        "  Checkpoint frequency: every {} steps (blast radius limit)",
+        config.checkpoint_every_steps
+    );
     eprintln!("  Use --experimental-mps only if you understand the risks.");
     eprintln!();
 }
@@ -123,9 +119,8 @@ pub fn validate_mps_config(config: &MpsConfig) -> MpsValidation {
     }
 
     if config.thread_percentage < 10 {
-        errors.push(
-            "Thread percentage below 10% causes severe performance degradation.".to_string(),
-        );
+        errors
+            .push("Thread percentage below 10% causes severe performance degradation.".to_string());
     }
 
     if config.pinned_mem_limit_mb.is_none() {
@@ -202,7 +197,9 @@ mod tests {
     fn test_setup_mps_env_sets_mem_limit() {
         let config = MpsConfig::with_share(50).with_mem_limit(8000);
         let vars = setup_mps_env(&config);
-        assert!(vars.iter().any(|(k, v)| k == "CUDA_MPS_PINNED_DEVICE_MEM_LIMIT" && v == "0=8000MB"));
+        assert!(vars
+            .iter()
+            .any(|(k, v)| k == "CUDA_MPS_PINNED_DEVICE_MEM_LIMIT" && v == "0=8000MB"));
     }
 
     #[test]

--- a/src/gpu/placement.rs
+++ b/src/gpu/placement.rs
@@ -75,12 +75,7 @@ pub fn place_adapters(
         .nodes
         .iter()
         .enumerate()
-        .map(|(i, _)| {
-            initial_load
-                .get(i)
-                .cloned()
-                .unwrap_or_default()
-        })
+        .map(|(i, _)| initial_load.get(i).cloned().unwrap_or_default())
         .collect();
 
     let mut placements = Vec::new();
@@ -165,10 +160,7 @@ fn node_flops_factor(node: &NodeConfig) -> f64 {
     if node.gpus.is_empty() {
         return 0.01; // CPU-only
     }
-    node.gpus
-        .iter()
-        .map(|g| gpu_flops_factor(&g.gpu_type))
-        .fold(0.0_f64, f64::max)
+    node.gpus.iter().map(|g| gpu_flops_factor(&g.gpu_type)).fold(0.0_f64, f64::max)
 }
 
 #[cfg(test)]
@@ -245,10 +237,7 @@ nodes:
     fn test_score_node_with_load() {
         let cluster = test_cluster();
         let desktop = &cluster.nodes[0];
-        let load = NodeLoad {
-            active_adapters: 1,
-            reserved_vram_mb: 8000,
-        };
+        let load = NodeLoad { active_adapters: 1, reserved_vram_mb: 8000 };
         // free = 20879 - 8000 = 12879
         // score = (12879 / 8000) * 1.0 * (1 / 2) = 0.804
         let score = score_node(desktop, 8000, &load);
@@ -269,11 +258,8 @@ nodes:
     #[test]
     fn test_place_single_adapter() {
         let cluster = test_cluster();
-        let jobs = vec![AdapterJob {
-            adapter_idx: 0,
-            budget_mb: 8000,
-            label: "adapter-0".to_string(),
-        }];
+        let jobs =
+            vec![AdapterJob { adapter_idx: 0, budget_mb: 8000, label: "adapter-0".to_string() }];
         let placements = place_adapters(&cluster, &jobs, &[]);
         assert_eq!(placements.len(), 1);
         assert_eq!(placements[0].node_name, "desktop"); // highest score
@@ -284,11 +270,7 @@ nodes:
     fn test_place_multiple_adapters_greedy() {
         let cluster = test_cluster();
         let jobs: Vec<AdapterJob> = (0..4)
-            .map(|i| AdapterJob {
-                adapter_idx: i,
-                budget_mb: 6000,
-                label: format!("adapter-{i}"),
-            })
+            .map(|i| AdapterJob { adapter_idx: i, budget_mb: 6000, label: format!("adapter-{i}") })
             .collect();
         let placements = place_adapters(&cluster, &jobs, &[]);
 
@@ -336,17 +318,11 @@ nodes:
     #[test]
     fn test_place_with_initial_load() {
         let cluster = test_cluster();
-        let jobs = vec![AdapterJob {
-            adapter_idx: 0,
-            budget_mb: 6000,
-            label: "adapter-0".to_string(),
-        }];
+        let jobs =
+            vec![AdapterJob { adapter_idx: 0, budget_mb: 6000, label: "adapter-0".to_string() }];
         // Desktop already has 3 adapters (full)
         let load = vec![
-            NodeLoad {
-                active_adapters: 3,
-                reserved_vram_mb: 18000,
-            },
+            NodeLoad { active_adapters: 3, reserved_vram_mb: 18000 },
             NodeLoad::default(),
             NodeLoad::default(),
         ];

--- a/src/gpu/profiler.rs
+++ b/src/gpu/profiler.rs
@@ -27,9 +27,8 @@ pub const LOCK_REL: usize = 4;
 pub const WAIT_POLL: usize = 5;
 const NUM_GPU_PHASES: usize = 6;
 
-const GPU_PHASE_NAMES: [&str; NUM_GPU_PHASES] = [
-    "lock_acq", "ledger_rd", "vram_qry", "ledger_wr", "lock_rel", "wait_poll",
-];
+const GPU_PHASE_NAMES: [&str; NUM_GPU_PHASES] =
+    ["lock_acq", "ledger_rd", "vram_qry", "ledger_wr", "lock_rel", "wait_poll"];
 
 /// Brick-phase profiler for GPU sharing operations.
 pub struct GpuProfiler {
@@ -126,10 +125,7 @@ impl GpuProfiler {
             "│ {:>10} │ {:>6} │ {:>8} │ {:>6} │\n",
             "phase", "count", "total_ms", "pct"
         ));
-        out.push_str(&format!(
-            "│ {:-<10} │ {:-<6} │ {:-<8} │ {:-<6} │\n",
-            "", "", "", ""
-        ));
+        out.push_str(&format!("│ {:-<10} │ {:-<6} │ {:-<8} │ {:-<6} │\n", "", "", "", ""));
 
         for i in 0..NUM_GPU_PHASES {
             let ms = self.totals[i].as_micros() as f64 / 1000.0;

--- a/src/gpu/wait.rs
+++ b/src/gpu/wait.rs
@@ -30,7 +30,7 @@ impl Default for WaitConfig {
         Self {
             timeout: Duration::from_secs(3600),     // 1 hour
             base_interval: Duration::from_secs(30), // 30 seconds
-            max_interval: Duration::from_secs(300),  // 5 minutes
+            max_interval: Duration::from_secs(300), // 5 minutes
         }
     }
 }
@@ -38,10 +38,7 @@ impl Default for WaitConfig {
 impl WaitConfig {
     /// Create config with custom timeout in seconds.
     pub fn with_timeout_secs(secs: u64) -> Self {
-        Self {
-            timeout: Duration::from_secs(secs),
-            ..Default::default()
-        }
+        Self { timeout: Duration::from_secs(secs), ..Default::default() }
     }
 
     /// Compute the sleep interval for a given attempt number.
@@ -69,10 +66,7 @@ pub fn wait_for_vram(
     loop {
         // Check timeout BEFORE trying (not after sleep)
         if start.elapsed() > config.timeout {
-            return Err(GpuError::Timeout {
-                budget_mb,
-                timeout_secs: config.timeout.as_secs(),
-            });
+            return Err(GpuError::Timeout { budget_mb, timeout_secs: config.timeout.as_secs() });
         }
 
         // Phase: wait_poll
@@ -133,8 +127,7 @@ mod tests {
     #[test]
     fn test_immediate_success() {
         let path = test_ledger_path();
-        let mut ledger = VramLedger::new("GPU-test".into(), 24000, 0.85)
-            .with_path(path.clone());
+        let mut ledger = VramLedger::new("GPU-test".into(), 24000, 0.85).with_path(path.clone());
         let mut profiler = GpuProfiler::disabled();
         let config = WaitConfig::with_timeout_secs(5);
 
@@ -147,8 +140,7 @@ mod tests {
     #[test]
     fn test_timeout_when_full() {
         let path = test_ledger_path();
-        let mut ledger = VramLedger::new("GPU-test".into(), 10000, 0.85)
-            .with_path(path.clone());
+        let mut ledger = VramLedger::new("GPU-test".into(), 10000, 0.85).with_path(path.clone());
 
         // Fill the ledger
         ledger.try_reserve(8000, "blocker").unwrap();
@@ -203,8 +195,7 @@ mod tests {
         std::thread::sleep(Duration::from_millis(10));
 
         // Waiter should succeed because the lease expired
-        let mut waiter = VramLedger::new("GPU-test".into(), 10000, 0.85)
-            .with_path(path.clone());
+        let mut waiter = VramLedger::new("GPU-test".into(), 10000, 0.85).with_path(path.clone());
         let mut profiler = GpuProfiler::disabled();
         let config = WaitConfig::with_timeout_secs(5);
 

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -21,10 +21,6 @@ pub struct InferenceConfig {
 
 impl Default for InferenceConfig {
     fn default() -> Self {
-        Self {
-            model_path: String::new(),
-            max_seq_len: 2048,
-            greedy: true,
-        }
+        Self { model_path: String::new(), max_seq_len: 2048, greedy: true }
     }
 }

--- a/src/io/load.rs
+++ b/src/io/load.rs
@@ -438,9 +438,7 @@ mod tests {
     /// Model loading performance: load_bench / loading_time (PW-07)
     #[test]
     fn load_bench_loading_time() {
-        let params = vec![
-            ("w".to_string(), Tensor::from_vec(vec![1.0; 1000], false)),
-        ];
+        let params = vec![("w".to_string(), Tensor::from_vec(vec![1.0; 1000], false))];
         let original = Model::new(ModelMetadata::new("bench-model", "test"), params);
 
         let temp_file = NamedTempFile::new().expect("temp file creation should succeed");

--- a/src/monitor/tui/app.rs
+++ b/src/monitor/tui/app.rs
@@ -55,10 +55,7 @@ pub struct TuiMonitor {
 impl TuiMonitor {
     /// Create a new TUI monitor for an experiment
     pub fn new<P: AsRef<Path>>(experiment_dir: P, config: TuiMonitorConfig) -> Self {
-        Self {
-            config,
-            state: TrainingState::new(experiment_dir),
-        }
+        Self { config, state: TrainingState::new(experiment_dir) }
     }
 
     /// Run the TUI monitor loop using presentar-terminal (ALB-047/048).
@@ -81,7 +78,8 @@ impl TuiMonitor {
         eprintln!("Connected to training session. Press 'q' or Ctrl+C to detach.\n");
 
         // Create presentar dashboard widget
-        let experiment_dir = self.state.path().parent().unwrap_or(std::path::Path::new(".")).to_path_buf();
+        let experiment_dir =
+            self.state.path().parent().unwrap_or(std::path::Path::new(".")).to_path_buf();
         let dashboard = super::dashboard::TrainingDashboard::new(experiment_dir);
 
         // Launch presentar TuiApp — handles resize, Ctrl+C, cursor, smart diffing
@@ -93,13 +91,11 @@ impl TuiMonitor {
             .map_err(|e| io::Error::other(e.to_string()))?
             .with_config(config);
 
-        app.run()
-            .map_err(|e| io::Error::other(e.to_string()))?;
+        app.run().map_err(|e| io::Error::other(e.to_string()))?;
 
         eprintln!("\nDetached from training session. Training continues in background.");
         Ok(())
     }
-
 }
 
 #[cfg(test)]
@@ -293,7 +289,8 @@ impl TrainingStateWriter {
             let log_every = (self.snapshot.steps_per_epoch / 10)
                 .max(10)
                 .min(self.snapshot.steps_per_epoch.max(1));
-            if step == 1 || step.is_multiple_of(log_every) || step == self.snapshot.steps_per_epoch {
+            if step == 1 || step.is_multiple_of(log_every) || step == self.snapshot.steps_per_epoch
+            {
                 self.refresh_gpu_telemetry();
                 self.emit_console_progress();
             }
@@ -432,7 +429,9 @@ mod state_writer_tests {
         writer.set_epochs(10, 100);
         writer.start().expect("file write should succeed");
 
-        writer.update_step(1, 10, 0.5, 0.0002, 1.5, 1200.0, 0.75).expect("file write should succeed");
+        writer
+            .update_step(1, 10, 0.5, 0.0002, 1.5, 1200.0, 0.75)
+            .expect("file write should succeed");
 
         // Verify state was written
         let mut state = TrainingState::new(temp_dir.path());

--- a/src/monitor/tui/dashboard.rs
+++ b/src/monitor/tui/dashboard.rs
@@ -17,8 +17,8 @@ use presentar_core::{
     LayoutResult, Point, Rect, Size, TextStyle, TypeId, Widget,
 };
 use presentar_terminal::widgets::{
-    Border, GpuDevice, GpuPanel as PresentarGpuPanel, GpuProcess as PresentarGpuProcess,
-    GpuVendor, Layout, LayoutItem, Meter, Sparkline, Text,
+    Border, GpuDevice, GpuPanel as PresentarGpuPanel, GpuProcess as PresentarGpuProcess, GpuVendor,
+    Layout, LayoutItem, Meter, Sparkline, Text,
 };
 use std::any::Any;
 use std::path::PathBuf;
@@ -56,12 +56,7 @@ impl TrainingDashboard {
     /// Create a new training dashboard for an experiment directory.
     #[must_use]
     pub fn new(experiment_dir: PathBuf) -> Self {
-        Self {
-            snapshot: None,
-            experiment_dir,
-            bounds: Rect::default(),
-            widget_tree: None,
-        }
+        Self { snapshot: None, experiment_dir, bounds: Rect::default(), widget_tree: None }
     }
 
     /// Refresh the snapshot from training_state.json.
@@ -75,10 +70,7 @@ impl TrainingDashboard {
     /// Check if training is done (for app quit logic).
     pub fn is_finished(&self) -> bool {
         self.snapshot.as_ref().is_some_and(|s| {
-            matches!(
-                s.status,
-                TrainingStatus::Completed | TrainingStatus::Failed(_)
-            )
+            matches!(s.status, TrainingStatus::Completed | TrainingStatus::Failed(_))
         })
     }
 
@@ -112,8 +104,7 @@ impl TrainingDashboard {
 
         // Error message if failed
         if let TrainingStatus::Failed(msg) = &snap.status {
-            let err =
-                Text::new(format!("ERROR: {msg}")).with_color(Color::new(1.0, 0.3, 0.3, 1.0));
+            let err = Text::new(format!("ERROR: {msg}")).with_color(Color::new(1.0, 0.3, 0.3, 1.0));
             items.push(LayoutItem::new(err).fixed(1.0));
         }
 
@@ -129,19 +120,14 @@ impl TrainingDashboard {
 fn build_header(snap: &TrainingSnapshot) -> Layout {
     let (status_str, status_color) = status_display(&snap.status);
 
-    let title = Text::new(format!(
-        "apr monitor — {}",
-        truncate_str(&snap.experiment_id, 30)
-    ))
-    .with_color(Color::WHITE)
-    .bold();
+    let title = Text::new(format!("apr monitor — {}", truncate_str(&snap.experiment_id, 30)))
+        .with_color(Color::WHITE)
+        .bold();
 
     let status = Text::new(status_str).with_color(status_color).right();
 
-    let title_row = Layout::columns([
-        LayoutItem::new(title).expanded(),
-        LayoutItem::new(status).fixed(10.0),
-    ]);
+    let title_row =
+        Layout::columns([LayoutItem::new(title).expanded(), LayoutItem::new(status).fixed(10.0)]);
 
     let info = Text::new(format!(
         "Model: {} | Opt: {} | Batch: {}",
@@ -151,10 +137,7 @@ fn build_header(snap: &TrainingSnapshot) -> Layout {
     ))
     .with_color(Color::new(0.6, 0.6, 0.6, 1.0));
 
-    Layout::rows([
-        title_row.into_item().fixed(1.0),
-        LayoutItem::new(info).fixed(1.0),
-    ])
+    Layout::rows([title_row.into_item().fixed(1.0), LayoutItem::new(info).fixed(1.0)])
 }
 
 /// Build metrics panel: progress bar, loss, timing — inside a rounded border.
@@ -203,9 +186,8 @@ fn build_metrics_panel(snap: &TrainingSnapshot) -> Border {
 /// Build GPU panel: utilization, VRAM, temp/power — inside a rounded border.
 fn build_gpu_panel(snap: &TrainingSnapshot) -> Border {
     let Some(gpu) = &snap.gpu else {
-        return Border::rounded("GPU").child(
-            Text::new("N/A (CPU training)").with_color(Color::new(0.5, 0.5, 0.5, 1.0)),
-        );
+        return Border::rounded("GPU")
+            .child(Text::new("N/A (CPU training)").with_color(Color::new(0.5, 0.5, 0.5, 1.0)));
     };
 
     let device = convert_gpu_device(gpu);
@@ -225,17 +207,14 @@ fn build_loss_panel(snap: &TrainingSnapshot) -> Border {
     let first = snap.loss_history.first().copied().unwrap_or(0.0);
     let last = snap.loss_history.last().copied().unwrap_or(0.0);
 
-    let sparkline = Sparkline::new(values)
-        .with_color(Color::new(0.3, 0.7, 1.0, 1.0))
-        .with_trend(true);
+    let sparkline =
+        Sparkline::new(values).with_color(Color::new(0.3, 0.7, 1.0, 1.0)).with_trend(true);
 
     let range =
         Text::new(format!("{first:.4} → {last:.4}")).with_color(Color::new(0.5, 0.5, 0.5, 1.0));
 
-    let content = Layout::rows([
-        LayoutItem::new(sparkline).fixed(1.0),
-        LayoutItem::new(range).fixed(1.0),
-    ]);
+    let content =
+        Layout::rows([LayoutItem::new(sparkline).fixed(1.0), LayoutItem::new(range).fixed(1.0)]);
 
     Border::rounded("Loss History").child(content)
 }
@@ -258,9 +237,7 @@ fn convert_gpu_device(gpu: &super::state::GpuTelemetry) -> GpuDevice {
 }
 
 /// Convert entrenar `GpuProcessInfo` to presentar `GpuProcess`.
-fn convert_gpu_processes(
-    processes: &[super::state::GpuProcessInfo],
-) -> Vec<PresentarGpuProcess> {
+fn convert_gpu_processes(processes: &[super::state::GpuProcessInfo]) -> Vec<PresentarGpuProcess> {
     processes
         .iter()
         .map(|p| {
@@ -294,12 +271,7 @@ fn truncate_str(s: &str, max: usize) -> &str {
 fn format_duration(d: Duration) -> String {
     let secs = d.as_secs();
     if secs > 3600 {
-        format!(
-            "{}h {}m {}s",
-            secs / 3600,
-            (secs % 3600) / 60,
-            secs % 60
-        )
+        format!("{}h {}m {}s", secs / 3600, (secs % 3600) / 60, secs % 60)
     } else if secs > 60 {
         format!("{}m {}s", secs / 60, secs % 60)
     } else {
@@ -367,10 +339,7 @@ impl Widget for TrainingDashboard {
     }
 
     fn measure(&self, constraints: Constraints) -> Size {
-        Size {
-            width: constraints.max_width,
-            height: constraints.max_height,
-        }
+        Size { width: constraints.max_width, height: constraints.max_height }
     }
 
     fn layout(&mut self, bounds: Rect) -> LayoutResult {
@@ -384,12 +353,7 @@ impl Widget for TrainingDashboard {
             tree.layout(bounds);
         }
 
-        LayoutResult {
-            size: Size {
-                width: bounds.width,
-                height: bounds.height,
-            },
-        }
+        LayoutResult { size: Size { width: bounds.width, height: bounds.height } }
     }
 
     fn paint(&self, canvas: &mut dyn Canvas) {
@@ -400,15 +364,8 @@ impl Widget for TrainingDashboard {
         }
 
         // Fallback: waiting state
-        let dim = TextStyle {
-            color: Color::new(0.5, 0.5, 0.5, 1.0),
-            ..Default::default()
-        };
-        canvas.draw_text(
-            "Waiting for training data...",
-            Point { x: 1.0, y: 1.0 },
-            &dim,
-        );
+        let dim = TextStyle { color: Color::new(0.5, 0.5, 0.5, 1.0), ..Default::default() };
+        canvas.draw_text("Waiting for training data...", Point { x: 1.0, y: 1.0 }, &dim);
     }
 
     fn event(&mut self, event: &Event) -> Option<Box<dyn Any + Send>> {

--- a/src/numerical.rs
+++ b/src/numerical.rs
@@ -132,10 +132,7 @@ mod tests {
         let values = vec![2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0];
         let var = kahan_variance(&values);
         // Known variance for this dataset: 4.0
-        assert!(
-            (var - 4.0).abs() < 1e-5,
-            "Kahan variance = {var}, expected 4.0"
-        );
+        assert!((var - 4.0).abs() < 1e-5, "Kahan variance = {var}, expected 4.0");
     }
 
     #[test]
@@ -169,9 +166,7 @@ mod tests {
     fn test_kahan_vs_naive_accuracy() {
         // Alternating large and small values stress-test accumulation
         let n = 10_000;
-        let values: Vec<f32> = (0..n)
-            .map(|i| if i % 2 == 0 { 1e6 } else { 1e-6 })
-            .collect();
+        let values: Vec<f32> = (0..n).map(|i| if i % 2 == 0 { 1e6 } else { 1e-6 }).collect();
 
         let kahan = kahan_sum(&values);
         let naive: f32 = values.iter().sum();

--- a/src/optim/adamw.rs
+++ b/src/optim/adamw.rs
@@ -514,10 +514,7 @@ mod tests {
         for &beta in &[0.9_f32, 0.99, 0.999] {
             for t in 1..=100i32 {
                 let adjust = 1.0 / (1.0 - beta.powi(t));
-                assert!(
-                    adjust > 1.0,
-                    "FALSIFIED AW-003e: 1/(1-{beta}^{t}) = {adjust} not > 1"
-                );
+                assert!(adjust > 1.0, "FALSIFIED AW-003e: 1/(1-{beta}^{t}) = {adjust} not > 1");
             }
         }
     }

--- a/src/run.rs
+++ b/src/run.rs
@@ -101,12 +101,8 @@ pub struct Run<S: ExperimentStorage> {
 
 impl<S: ExperimentStorage> Run<S> {
     /// Acquire the storage mutex, mapping poison errors to `StorageError::Backend`.
-    fn lock_storage(
-        storage: &Arc<Mutex<S>>,
-    ) -> Result<std::sync::MutexGuard<'_, S>> {
-        storage
-            .lock()
-            .map_err(|e| StorageError::Backend(format!("mutex poisoned: {e}")))
+    fn lock_storage(storage: &Arc<Mutex<S>>) -> Result<std::sync::MutexGuard<'_, S>> {
+        storage.lock().map_err(|e| StorageError::Backend(format!("mutex poisoned: {e}")))
     }
 
     /// Acquire the storage mutex on `self`, mapping poison errors to `StorageError::Backend`.

--- a/src/sovereign/governance.rs
+++ b/src/sovereign/governance.rs
@@ -83,10 +83,7 @@ pub struct ApiAllowlist {
 
 impl Default for ApiAllowlist {
     fn default() -> Self {
-        Self {
-            allowed_endpoints: HashSet::new(),
-            offline_mode: true,
-        }
+        Self { allowed_endpoints: HashSet::new(), offline_mode: true }
     }
 }
 
@@ -101,10 +98,7 @@ impl ApiAllowlist {
 
     /// Create a fully offline allowlist (SDG-14)
     pub fn offline() -> Self {
-        Self {
-            allowed_endpoints: HashSet::new(),
-            offline_mode: true,
-        }
+        Self { allowed_endpoints: HashSet::new(), offline_mode: true }
     }
 }
 
@@ -142,10 +136,7 @@ pub struct AuditTrail {
 impl AuditTrail {
     /// Create a new empty audit trail
     pub fn new() -> Self {
-        Self {
-            entries: Vec::new(),
-            next_sequence: 0,
-        }
+        Self { entries: Vec::new(), next_sequence: 0 }
     }
 
     /// Append an entry to the audit trail (append-only)
@@ -155,9 +146,8 @@ impl AuditTrail {
         data: &str,
         classification: DataClassification,
     ) -> &AuditEntry {
-        let prev_hash = self
-            .entries
-            .last().map_or_else(|| "genesis".to_string(), |e| e.hash.clone());
+        let prev_hash =
+            self.entries.last().map_or_else(|| "genesis".to_string(), |e| e.hash.clone());
 
         let sequence = self.next_sequence;
         self.next_sequence += 1;
@@ -291,10 +281,7 @@ pub struct DeletionCascade {
 impl DeletionCascade {
     /// Create a deletion cascade for all storage locations
     pub fn full(targets: Vec<String>) -> Self {
-        Self {
-            targets,
-            requires_unlearning: true,
-        }
+        Self { targets, requires_unlearning: true }
     }
 
     /// Execute the cascade (dry run — returns list of actions)
@@ -324,10 +311,7 @@ pub struct SecureAggregator {
 impl SecureAggregator {
     /// Create a secure aggregation coordinator
     pub fn new(num_clients: usize) -> Self {
-        Self {
-            num_clients,
-            encrypted: true,
-        }
+        Self { num_clients, encrypted: true }
     }
 
     /// Aggregate encrypted gradients (secure_aggregation protocol)
@@ -359,10 +343,7 @@ pub fn enforce_tier(data_class: DataClassification) -> bool {
 }
 
 /// Validate access level against required classification (SDG-07)
-pub fn validate_access_level(
-    actual: DataClassification,
-    required: DataClassification,
-) -> bool {
+pub fn validate_access_level(actual: DataClassification, required: DataClassification) -> bool {
     let level = |c: &DataClassification| match c {
         DataClassification::Public => 0,
         DataClassification::Internal => 1,
@@ -395,9 +376,7 @@ pub struct DataUsageAgreement {
 impl DataUsageAgreement {
     /// Create empty agreement tracker
     pub fn new() -> Self {
-        Self {
-            records: Vec::new(),
-        }
+        Self { records: Vec::new() }
     }
 
     /// Add consent record
@@ -455,9 +434,7 @@ pub struct TransferLogEntry {
 impl TransferLog {
     /// Create a new transfer log
     pub fn new() -> Self {
-        Self {
-            entries: Vec::new(),
-        }
+        Self { entries: Vec::new() }
     }
 
     /// Log a data_export / international_transfer event
@@ -493,10 +470,7 @@ pub fn weight_access(model_acl: &[String], requester: &str) -> bool {
 /// Encrypt weights for sovereign_model protection (SDG-11)
 pub fn encrypt_weights(weights: &[f32], _key: &[u8]) -> Vec<u8> {
     // Placeholder: XOR-based sealed_model (encrypted_model format)
-    let bytes: Vec<u8> = weights
-        .iter()
-        .flat_map(|w| w.to_le_bytes())
-        .collect();
+    let bytes: Vec<u8> = weights.iter().flat_map(|w| w.to_le_bytes()).collect();
     bytes
 }
 
@@ -511,10 +485,7 @@ pub struct KeyManagement {
 
 impl Default for KeyManagement {
     fn default() -> Self {
-        Self {
-            key_rotation_interval: 86400,
-            kms_provider: "local".to_string(),
-        }
+        Self { key_rotation_interval: 86400, kms_provider: "local".to_string() }
     }
 }
 
@@ -588,11 +559,7 @@ mod tests {
         let mut trail = AuditTrail::new();
 
         trail.append("training_start", "model=350M", DataClassification::Internal);
-        trail.append(
-            "checkpoint_save",
-            "step=100",
-            DataClassification::Sovereign,
-        );
+        trail.append("checkpoint_save", "step=100", DataClassification::Sovereign);
         trail.append("training_end", "loss=5.92", DataClassification::Internal);
 
         assert_eq!(trail.len(), 3);
@@ -640,19 +607,14 @@ mod tests {
     #[test]
     fn test_classification_inheritance() {
         // Sovereign input should produce sovereign output
-        let result = inherit_classification(
-            DataClassification::Sovereign,
-            DataClassification::Internal,
-        );
+        let result =
+            inherit_classification(DataClassification::Sovereign, DataClassification::Internal);
         assert_eq!(result, DataClassification::Sovereign);
     }
 
     #[test]
     fn test_deletion_cascade_plan() {
-        let cascade = DeletionCascade::full(vec![
-            "checkpoints/".to_string(),
-            "logs/".to_string(),
-        ]);
+        let cascade = DeletionCascade::full(vec!["checkpoints/".to_string(), "logs/".to_string()]);
         let plan = cascade.plan();
         assert_eq!(plan.len(), 3); // 2 deletes + 1 unlearning
         assert!(plan[0].contains("checkpoints"));

--- a/src/sovereign/mod.rs
+++ b/src/sovereign/mod.rs
@@ -34,9 +34,9 @@ pub mod registry;
 pub use distribution::{
     ComponentManifest, DistributionFormat, DistributionTier, SovereignDistribution,
 };
-pub use nix::{CrateSpec, NixFlakeConfig, NixSystem};
 pub use governance::{
     ApiAllowlist, AuditEntry, AuditTrail, DataClassification, DeletionCascade, KeySource,
     ResidencyConfig, WeightSovereigntyConfig,
 };
+pub use nix::{CrateSpec, NixFlakeConfig, NixSystem};
 pub use registry::{ModelEntry, ModelSource, OfflineModelRegistry, RegistryManifest};

--- a/src/storage/sqlite/artifacts.rs
+++ b/src/storage/sqlite/artifacts.rs
@@ -14,11 +14,9 @@ impl SqliteBackend {
         let conn = self.lock_conn()?;
 
         let data: Vec<u8> = conn
-            .query_row(
-                "SELECT data FROM artifacts WHERE sha256 = ?1 LIMIT 1",
-                [sha256],
-                |row| row.get(0),
-            )
+            .query_row("SELECT data FROM artifacts WHERE sha256 = ?1 LIMIT 1", [sha256], |row| {
+                row.get(0)
+            })
             .map_err(|e| match e {
                 rusqlite::Error::QueryReturnedNoRows => {
                     StorageError::Backend(format!("Artifact not found: {sha256}"))
@@ -35,11 +33,9 @@ impl SqliteBackend {
 
         // Verify run exists
         let exists: bool = conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)",
-                [run_id],
-                |row| row.get(0),
-            )
+            .query_row("SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)", [run_id], |row| {
+                row.get(0)
+            })
             .map_err(|e| StorageError::Backend(format!("Failed to check run: {e}")))?;
 
         if !exists {
@@ -66,8 +62,8 @@ impl SqliteBackend {
 
         let mut result = Vec::new();
         for row in rows {
-            let (id, run_id, path, size_bytes, sha256, created_str) =
-                row.map_err(|e| StorageError::Backend(format!("Failed to read artifact row: {e}")))?;
+            let (id, run_id, path, size_bytes, sha256, created_str) = row
+                .map_err(|e| StorageError::Backend(format!("Failed to read artifact row: {e}")))?;
             let created_at = created_str.parse().unwrap_or_else(|_| Utc::now());
             result.push(ArtifactRef {
                 id,

--- a/src/storage/sqlite/backend/schema.rs
+++ b/src/storage/sqlite/backend/schema.rs
@@ -24,16 +24,9 @@ pub fn init_schema(conn: &Connection) -> Result<(), rusqlite::Error> {
     conn.execute_batch(SCHEMA_SQL)?;
 
     // Insert schema version if not present
-    let count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM schema_version",
-        [],
-        |row| row.get(0),
-    )?;
+    let count: i64 = conn.query_row("SELECT COUNT(*) FROM schema_version", [], |row| row.get(0))?;
     if count == 0 {
-        conn.execute(
-            "INSERT INTO schema_version (version) VALUES (?1)",
-            [CURRENT_VERSION],
-        )?;
+        conn.execute("INSERT INTO schema_version (version) VALUES (?1)", [CURRENT_VERSION])?;
     }
 
     Ok(())

--- a/src/storage/sqlite/backend/tests/concurrency_tests.rs
+++ b/src/storage/sqlite/backend/tests/concurrency_tests.rs
@@ -16,16 +16,13 @@ fn test_sqlite_backend_is_send_sync() {
 #[test]
 fn test_sequential_metric_logging() {
     let mut backend = SqliteBackend::open_in_memory().expect("operation should succeed");
-    let exp_id =
-        backend.create_experiment("test-exp", None).expect("operation should succeed");
+    let exp_id = backend.create_experiment("test-exp", None).expect("operation should succeed");
     let run_id = backend.create_run(&exp_id).expect("operation should succeed");
 
     backend.start_run(&run_id).expect("operation should succeed");
 
     for i in 0..10 {
-        backend
-            .log_metric(&run_id, "loss", i, i as f64 * 0.1)
-            .expect("operation should succeed");
+        backend.log_metric(&run_id, "loss", i, i as f64 * 0.1).expect("operation should succeed");
     }
 
     let metrics = backend.get_metrics(&run_id, "loss").expect("operation should succeed");

--- a/src/storage/sqlite/metrics.rs
+++ b/src/storage/sqlite/metrics.rs
@@ -83,9 +83,7 @@ impl ExperimentStorage for SqliteBackend {
         let conn = self.lock_conn()?;
 
         let current_status: String = conn
-            .query_row("SELECT status FROM runs WHERE id = ?1", [run_id], |row| {
-                row.get(0)
-            })
+            .query_row("SELECT status FROM runs WHERE id = ?1", [run_id], |row| row.get(0))
             .map_err(|e| match e {
                 rusqlite::Error::QueryReturnedNoRows => {
                     StorageError::RunNotFound(run_id.to_string())
@@ -113,9 +111,7 @@ impl ExperimentStorage for SqliteBackend {
         let conn = self.lock_conn()?;
 
         let current_status: String = conn
-            .query_row("SELECT status FROM runs WHERE id = ?1", [run_id], |row| {
-                row.get(0)
-            })
+            .query_row("SELECT status FROM runs WHERE id = ?1", [run_id], |row| row.get(0))
             .map_err(|e| match e {
                 rusqlite::Error::QueryReturnedNoRows => {
                     StorageError::RunNotFound(run_id.to_string())
@@ -144,11 +140,9 @@ impl ExperimentStorage for SqliteBackend {
 
         // Verify run exists
         let exists: bool = conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)",
-                [run_id],
-                |row| row.get(0),
-            )
+            .query_row("SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)", [run_id], |row| {
+                row.get(0)
+            })
             .map_err(|e| StorageError::Backend(format!("Failed to check run: {e}")))?;
 
         if !exists {
@@ -170,11 +164,9 @@ impl ExperimentStorage for SqliteBackend {
 
         // Verify run exists
         let exists: bool = conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)",
-                [run_id],
-                |row| row.get(0),
-            )
+            .query_row("SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)", [run_id], |row| {
+                row.get(0)
+            })
             .map_err(|e| StorageError::Backend(format!("Failed to check run: {e}")))?;
 
         if !exists {
@@ -203,11 +195,9 @@ impl ExperimentStorage for SqliteBackend {
 
         // Verify run exists
         let exists: bool = conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)",
-                [run_id],
-                |row| row.get(0),
-            )
+            .query_row("SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)", [run_id], |row| {
+                row.get(0)
+            })
             .map_err(|e| StorageError::Backend(format!("Failed to check run: {e}")))?;
 
         if !exists {
@@ -223,9 +213,7 @@ impl ExperimentStorage for SqliteBackend {
                 let step: i64 = row.get(0)?;
                 let value: f64 = row.get(1)?;
                 let ts_str: String = row.get(2)?;
-                let timestamp: DateTime<Utc> = ts_str
-                    .parse()
-                    .unwrap_or_else(|_| Utc::now());
+                let timestamp: DateTime<Utc> = ts_str.parse().unwrap_or_else(|_| Utc::now());
                 Ok(MetricPoint::with_timestamp(step as u64, value, timestamp))
             })
             .map_err(|e| StorageError::Backend(format!("Failed to query metrics: {e}")))?
@@ -239,9 +227,7 @@ impl ExperimentStorage for SqliteBackend {
         let conn = self.lock_conn()?;
 
         let status_str: String = conn
-            .query_row("SELECT status FROM runs WHERE id = ?1", [run_id], |row| {
-                row.get(0)
-            })
+            .query_row("SELECT status FROM runs WHERE id = ?1", [run_id], |row| row.get(0))
             .map_err(|e| match e {
                 rusqlite::Error::QueryReturnedNoRows => {
                     StorageError::RunNotFound(run_id.to_string())
@@ -257,11 +243,9 @@ impl ExperimentStorage for SqliteBackend {
 
         // Verify run exists
         let exists: bool = conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)",
-                [run_id],
-                |row| row.get(0),
-            )
+            .query_row("SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)", [run_id], |row| {
+                row.get(0)
+            })
             .map_err(|e| StorageError::Backend(format!("Failed to check run: {e}")))?;
 
         if !exists {
@@ -282,22 +266,19 @@ impl ExperimentStorage for SqliteBackend {
 
         // Verify run exists
         let exists: bool = conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)",
-                [run_id],
-                |row| row.get(0),
-            )
+            .query_row("SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)", [run_id], |row| {
+                row.get(0)
+            })
             .map_err(|e| StorageError::Backend(format!("Failed to check run: {e}")))?;
 
         if !exists {
             return Err(StorageError::RunNotFound(run_id.to_string()));
         }
 
-        let result = conn.query_row(
-            "SELECT span_id FROM span_ids WHERE run_id = ?1",
-            [run_id],
-            |row| row.get(0),
-        );
+        let result =
+            conn.query_row("SELECT span_id FROM span_ids WHERE run_id = ?1", [run_id], |row| {
+                row.get(0)
+            });
 
         match result {
             Ok(span_id) => Ok(Some(span_id)),

--- a/src/storage/sqlite/queries.rs
+++ b/src/storage/sqlite/queries.rs
@@ -33,11 +33,9 @@ impl SqliteBackend {
 
         // Verify run exists
         let exists: bool = conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)",
-                [run_id],
-                |row| row.get(0),
-            )
+            .query_row("SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)", [run_id], |row| {
+                row.get(0)
+            })
             .map_err(|e| StorageError::Backend(format!("Failed to check run: {e}")))?;
 
         if !exists {
@@ -57,16 +55,18 @@ impl SqliteBackend {
     }
 
     /// Log multiple parameters for a run
-    pub fn log_params(&self, run_id: &str, params_map: HashMap<String, ParameterValue>) -> Result<()> {
+    pub fn log_params(
+        &self,
+        run_id: &str,
+        params_map: HashMap<String, ParameterValue>,
+    ) -> Result<()> {
         let conn = self.lock_conn()?;
 
         // Verify run exists
         let exists: bool = conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)",
-                [run_id],
-                |row| row.get(0),
-            )
+            .query_row("SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)", [run_id], |row| {
+                row.get(0)
+            })
             .map_err(|e| StorageError::Backend(format!("Failed to check run: {e}")))?;
 
         if !exists {
@@ -93,11 +93,9 @@ impl SqliteBackend {
 
         // Verify run exists
         let exists: bool = conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)",
-                [run_id],
-                |row| row.get(0),
-            )
+            .query_row("SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1)", [run_id], |row| {
+                row.get(0)
+            })
             .map_err(|e| StorageError::Backend(format!("Failed to check run: {e}")))?;
 
         if !exists {

--- a/src/train/loss/mod.rs
+++ b/src/train/loss/mod.rs
@@ -11,14 +11,14 @@
 //! - [`WeightedLoss`] - Scalar weighting wrapper
 //! - [`SampleWeightedLoss`] - Per-sample weighting for curriculum learning
 
+#[cfg(test)]
+mod accuracy_tests;
 mod bce_with_logits;
 mod causal_lm;
 mod cross_entropy;
 mod mse;
 mod traits;
 mod weighted;
-#[cfg(test)]
-mod accuracy_tests;
 
 pub use bce_with_logits::BCEWithLogitsLoss;
 pub use causal_lm::CausalLMLoss;

--- a/src/train/mod.rs
+++ b/src/train/mod.rs
@@ -59,25 +59,44 @@ pub use loss::{
 };
 pub use metrics::{Accuracy, F1Score, Metric, Precision, R2Score, Recall, MAE, RMSE};
 pub use trainer::{TrainResult, Trainer};
-pub use transformer_trainer::{
-    perplexity, tokens_per_second, BlockGradientSet, CudaTransformerTrainer,
-    DistributedBackend, DistributedCheckpointCoordinator, DistributedRole,
-    DistributedTrainConfig, ElasticCoordinator, LMBatch, PerBlockGradientAccumulator,
-    TransformerTrainConfig, TransformerTrainer,
-    // DDP (#133)
-    shard_batches,
-    // Parallelism strategies
-    CausalMaskType, ColumnParallelShard, OptimizerShard, PipelineAction,
-    PipelineActivationBuffer, PipelineStage, RingAttentionSchedule, RowParallelShard,
-    SequenceParallelConfig, SpCommCost, TensorParallelConfig, TpCommCost, ZeroShardMap,
-};
-#[cfg(feature = "cuda")]
-pub use transformer_trainer::{DistributedCudaTrainer, DistributedComm};
 pub use transformer_trainer::distributed_checkpoint::{
     checkpoint_path, hash_weights, should_save_checkpoint, verify_weight_consistency,
     CheckpointPhase,
 };
 pub use transformer_trainer::grad_accumulator::BLOCK_GRAD_COMPONENTS;
+pub use transformer_trainer::{
+    perplexity,
+    // DDP (#133)
+    shard_batches,
+    tokens_per_second,
+    BlockGradientSet,
+    // Parallelism strategies
+    CausalMaskType,
+    ColumnParallelShard,
+    CudaTransformerTrainer,
+    DistributedBackend,
+    DistributedCheckpointCoordinator,
+    DistributedRole,
+    DistributedTrainConfig,
+    ElasticCoordinator,
+    LMBatch,
+    OptimizerShard,
+    PerBlockGradientAccumulator,
+    PipelineAction,
+    PipelineActivationBuffer,
+    PipelineStage,
+    RingAttentionSchedule,
+    RowParallelShard,
+    SequenceParallelConfig,
+    SpCommCost,
+    TensorParallelConfig,
+    TpCommCost,
+    TransformerTrainConfig,
+    TransformerTrainer,
+    ZeroShardMap,
+};
+#[cfg(feature = "cuda")]
+pub use transformer_trainer::{DistributedComm, DistributedCudaTrainer};
 pub use tui::{
     format_duration, sparkline, sparkline_range, Alert, AlertLevel, AndonSystem, DashboardLayout,
     FeatureImportanceChart, GradientFlowHeatmap, KalmanEta, LossCurveDisplay, MetricsBuffer,

--- a/src/train/transformer_trainer/config.rs
+++ b/src/train/transformer_trainer/config.rs
@@ -6,8 +6,7 @@ use crate::transformer::TransformerConfig;
 use std::net::SocketAddr;
 
 /// Role of a node in distributed pretraining.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DistributedRole {
     /// Coordinates training: AllReduces gradients, manages checkpoints
     #[default]
@@ -16,10 +15,8 @@ pub enum DistributedRole {
     Worker,
 }
 
-
 /// Compute backend for a distributed worker.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DistributedBackend {
     /// NVIDIA CUDA
     Cuda,
@@ -29,7 +26,6 @@ pub enum DistributedBackend {
     #[default]
     Auto,
 }
-
 
 /// Configuration for distributed pretraining (DDP).
 ///

--- a/src/train/transformer_trainer/cuda_trainer.rs
+++ b/src/train/transformer_trainer/cuda_trainer.rs
@@ -44,19 +44,19 @@ use crate::autograd::cuda_backward::{gemm_backward_a, gemm_backward_b, rms_norm_
 use crate::autograd::cuda_forward::{gemm_forward, pre_warm_forward_kernels, rms_norm_forward};
 #[cfg(feature = "cuda")]
 use crate::autograd::cuda_optim::{
-    adamw_step_cuda, fused_cross_entropy_cuda, gradient_clip_cuda,
-    squared_sum_cuda, squared_sum_launch_cuda, squared_sum_collect,
+    adamw_step_cuda, fused_cross_entropy_cuda, gradient_clip_cuda, squared_sum_collect,
+    squared_sum_cuda, squared_sum_launch_cuda,
 };
 #[cfg(feature = "cuda")]
 use crate::autograd::cuda_training::{cuda_training_available, CudaTrainer};
+#[cfg(feature = "cuda")]
+use crate::autograd::precision::GradScaler;
 #[cfg(feature = "cuda")]
 use crate::autograd::Tensor;
 #[cfg(feature = "cuda")]
 use crate::io::{save_model, Model, ModelFormat, ModelMetadata, SaveConfig};
 #[cfg(feature = "cuda")]
 use crate::optim::{AdamW, Optimizer};
-#[cfg(feature = "cuda")]
-use crate::autograd::precision::GradScaler;
 #[cfg(feature = "cuda")]
 use crate::train::MetricsTracker;
 #[cfg(feature = "cuda")]
@@ -86,9 +86,15 @@ fn compute_workspace_clip_scale_gpu(
     use crate::autograd::cuda_optim::PendingSquaredSum;
 
     let all_bufs: [&GpuBuffer<f32>; 9] = [
-        &ws.grad_w_q, &ws.grad_w_k, &ws.grad_w_v, &ws.grad_w_o,
-        &ws.grad_gate, &ws.grad_up, &ws.grad_down,
-        &ws.grad_input_norm, &ws.grad_post_attn_norm,
+        &ws.grad_w_q,
+        &ws.grad_w_k,
+        &ws.grad_w_v,
+        &ws.grad_w_o,
+        &ws.grad_gate,
+        &ws.grad_up,
+        &ws.grad_down,
+        &ws.grad_input_norm,
+        &ws.grad_post_attn_norm,
     ];
 
     // KAIZEN-055: Launch all 9 squared_sum kernels back-to-back without syncing.
@@ -119,11 +125,7 @@ fn compute_workspace_clip_scale_gpu(
     }
 
     let grad_norm = total_sq.sqrt() as f32;
-    let scale = if grad_norm > max_norm {
-        max_norm / grad_norm
-    } else {
-        1.0
-    };
+    let scale = if grad_norm > max_norm { max_norm / grad_norm } else { 1.0 };
     (scale, grad_norm)
 }
 
@@ -339,9 +341,7 @@ impl CudaTransformerTrainer {
     /// Returns `Err` if CUDA initialization fails.
     pub fn with_model(model: Transformer, config: TransformerTrainConfig) -> crate::Result<Self> {
         if !cuda_training_available() {
-            return Err(crate::error::Error::ConfigError(
-                "CUDA not available".into(),
-            ));
+            return Err(crate::error::Error::ConfigError("CUDA not available".into()));
         }
 
         let mc = &config.model_config;
@@ -374,9 +374,7 @@ impl CudaTransformerTrainer {
             mc.head_dim(),
             max_seq_len,
         )
-        .map_err(|e| {
-            crate::error::Error::ConfigError(format!("Kernel pre-warm failed: {e:?}"))
-        })?;
+        .map_err(|e| crate::error::Error::ConfigError(format!("Kernel pre-warm failed: {e:?}")))?;
 
         // Step 3: Upload transformer blocks to GPU
         let mut cuda_blocks = Vec::with_capacity(num_layers);
@@ -422,17 +420,14 @@ impl CudaTransformerTrainer {
         } else {
             1 // Every layer is a checkpoint (no recomputation)
         };
-        let saved_layer_mask: Vec<bool> = (0..num_layers)
-            .map(|i| !checkpointing || i % segment_size == 0)
-            .collect();
+        let saved_layer_mask: Vec<bool> =
+            (0..num_layers).map(|i| !checkpointing || i % segment_size == 0).collect();
 
         let mut layer_inputs = Vec::with_capacity(num_layers);
         for _ in 0..num_layers {
-            layer_inputs.push(
-                GpuBuffer::new(&ctx, buf_size).map_err(|e| {
-                    crate::error::Error::ConfigError(format!("Layer input alloc failed: {e:?}"))
-                })?,
-            );
+            layer_inputs.push(GpuBuffer::new(&ctx, buf_size).map_err(|e| {
+                crate::error::Error::ConfigError(format!("Layer input alloc failed: {e:?}"))
+            })?);
         }
 
         // Allocate recompute buffer if checkpointing is enabled
@@ -506,11 +501,7 @@ impl CudaTransformerTrainer {
 
         // Step 6: Upload LM head weight to GPU
         // Use tied weights (embed_tokens.weight) or separate lm_head
-        let lm_head_data = model
-            .lm_head
-            .as_ref()
-            .unwrap_or(&model.embed_tokens.weight)
-            .data();
+        let lm_head_data = model.lm_head.as_ref().unwrap_or(&model.embed_tokens.weight).data();
         let lm_head_slice = lm_head_data.as_slice().expect("contiguous");
         let lm_head_weight_gpu = GpuBuffer::from_host(&ctx, lm_head_slice).map_err(|e| {
             crate::error::Error::ConfigError(format!("LM head upload failed: {e:?}"))
@@ -520,12 +511,14 @@ impl CudaTransformerTrainer {
         })?;
         // CRITICAL: Must zero-initialize m/v buffers. GpuBuffer::new() does NOT
         // zero memory (cuMemAlloc returns uninitialized VRAM).
-        let lm_head_m = GpuBuffer::from_host(&ctx, &vec![0.0f32; vocab_size * hidden_size]).map_err(|e| {
-            crate::error::Error::ConfigError(format!("LM head m alloc failed: {e:?}"))
-        })?;
-        let lm_head_v = GpuBuffer::from_host(&ctx, &vec![0.0f32; vocab_size * hidden_size]).map_err(|e| {
-            crate::error::Error::ConfigError(format!("LM head v alloc failed: {e:?}"))
-        })?;
+        let lm_head_m = GpuBuffer::from_host(&ctx, &vec![0.0f32; vocab_size * hidden_size])
+            .map_err(|e| {
+                crate::error::Error::ConfigError(format!("LM head m alloc failed: {e:?}"))
+            })?;
+        let lm_head_v = GpuBuffer::from_host(&ctx, &vec![0.0f32; vocab_size * hidden_size])
+            .map_err(|e| {
+                crate::error::Error::ConfigError(format!("LM head v alloc failed: {e:?}"))
+            })?;
 
         // Final norm optimizer states
         let final_norm_m = GpuBuffer::from_host(&ctx, &vec![0.0f32; hidden_size]).map_err(|e| {
@@ -545,9 +538,9 @@ impl CudaTransformerTrainer {
         })?;
 
         // Sync to ensure all uploads completed
-        stream.synchronize().map_err(|e| {
-            crate::error::Error::ConfigError(format!("Stream sync failed: {e:?}"))
-        })?;
+        stream
+            .synchronize()
+            .map_err(|e| crate::error::Error::ConfigError(format!("Stream sync failed: {e:?}")))?;
 
         println!(
             "  ✓ GPU training state allocated (LM head: {:.1} MB)",
@@ -556,23 +549,24 @@ impl CudaTransformerTrainer {
 
         // KAIZEN-050: loss_fn removed — cross-entropy computed by fused GPU kernel
         // C-EMBED-GRAD-001: CPU optimizer must match YAML hyperparams (not defaults)
-        let embed_optimizer = AdamW::new(
-            config.lr,
-            config.beta1,
-            config.beta2,
-            1e-8,
-            config.weight_decay,
-        );
+        let embed_optimizer =
+            AdamW::new(config.lr, config.beta1, config.beta2, 1e-8, config.weight_decay);
 
         // R-038: Allocate per-block gradient accumulation buffers (CPU-side)
         // when accumulation_steps > 1 for true gradient accumulation.
         let grad_accum = if config.accumulation_steps > 1 {
             let kv_hidden = mc.num_kv_heads * mc.head_dim();
-            let block_sizes = super::grad_accumulator::PerBlockGradientAccumulator::compute_block_sizes(
-                hidden_size, kv_hidden, mc.intermediate_size,
-            );
+            let block_sizes =
+                super::grad_accumulator::PerBlockGradientAccumulator::compute_block_sizes(
+                    hidden_size,
+                    kv_hidden,
+                    mc.intermediate_size,
+                );
             let accum = super::grad_accumulator::PerBlockGradientAccumulator::new(
-                num_layers, block_sizes, vocab_size, hidden_size,
+                num_layers,
+                block_sizes,
+                vocab_size,
+                hidden_size,
             );
             println!(
                 "  ✓ Gradient accumulation: {} steps, CPU buffers ({:.1} MB)",
@@ -580,7 +574,9 @@ impl CudaTransformerTrainer {
                 (accum.block_grads.iter().map(|b| b.total_elements()).sum::<usize>()
                     + accum.lm_head_grad.len()
                     + accum.final_norm_grad.len()
-                    + accum.embedding_grad.len()) as f64 * 4.0 / 1e6,
+                    + accum.embedding_grad.len()) as f64
+                    * 4.0
+                    / 1e6,
             );
             Some(accum)
         } else {
@@ -700,7 +696,8 @@ impl CudaTransformerTrainer {
             vocab_size as u32,
             loss_scale,
             stream,
-        ).ok()?;
+        )
+        .ok()?;
 
         // NaN guard (replaces logits NaN check — NaN logits → NaN loss via kernel)
         if !loss_val.is_finite() {
@@ -762,11 +759,18 @@ impl CudaTransformerTrainer {
         for (i, block) in self.cuda_blocks.iter_mut().enumerate() {
             // Use raw pointers for the ping-pong to avoid borrow conflicts
             // with self.gpu_training.layer_inputs
-            let (input_ptr, output_ptr): (*const GpuBuffer<f32>, *mut GpuBuffer<f32>) = if input_is_a {
-                (std::ptr::from_ref(&self.fwd_scratch_a), std::ptr::from_mut(&mut self.fwd_scratch_b))
-            } else {
-                (std::ptr::from_ref(&self.fwd_scratch_b), std::ptr::from_mut(&mut self.fwd_scratch_a))
-            };
+            let (input_ptr, output_ptr): (*const GpuBuffer<f32>, *mut GpuBuffer<f32>) =
+                if input_is_a {
+                    (
+                        std::ptr::from_ref(&self.fwd_scratch_a),
+                        std::ptr::from_mut(&mut self.fwd_scratch_b),
+                    )
+                } else {
+                    (
+                        std::ptr::from_ref(&self.fwd_scratch_b),
+                        std::ptr::from_mut(&mut self.fwd_scratch_a),
+                    )
+                };
             if self.gpu_training.saved_layer_mask[i] {
                 // SAFETY: Both buffers are valid GPU allocations with matching max_seq_len size.
                 // Copy completes before block.forward() reads from input (same stream ordering).
@@ -785,16 +789,14 @@ impl CudaTransformerTrainer {
         self.profiler.end(StepProfiler::FORWARD);
 
         // After the loop, input_is_a tells us which buffer has the final output
-        let final_output: &GpuBuffer<f32> = if input_is_a { &self.fwd_scratch_a } else { &self.fwd_scratch_b };
+        let final_output: &GpuBuffer<f32> =
+            if input_is_a { &self.fwd_scratch_a } else { &self.fwd_scratch_b };
 
         // Save blocks output for final norm backward
         // SAFETY: Disjoint GPU buffers with matching max_seq_len sizes.
         self.profiler.begin(StepProfiler::NORM_LM);
         unsafe {
-            self.gpu_training
-                .blocks_output
-                .copy_from_buffer_async(final_output, stream)
-                .ok()?;
+            self.gpu_training.blocks_output.copy_from_buffer_async(final_output, stream).ok()?;
         }
 
         // Final RMSNorm forward (GPU)
@@ -854,9 +856,7 @@ impl CudaTransformerTrainer {
         stream: &CudaStream,
     ) -> Option<()> {
         // Find nearest saved checkpoint at or before target
-        let seg_start = (0..=target_layer)
-            .rev()
-            .find(|&i| gpu_training.saved_layer_mask[i])?;
+        let seg_start = (0..=target_layer).rev().find(|&i| gpu_training.saved_layer_mask[i])?;
 
         if seg_start == target_layer {
             return Some(()); // Already saved
@@ -867,10 +867,7 @@ impl CudaTransformerTrainer {
         let recompute_buf = gpu_training.recompute_buf.as_mut()?;
         unsafe {
             recompute_buf
-                .copy_from_buffer_async(
-                    &gpu_training.layer_inputs[seg_start],
-                    stream,
-                )
+                .copy_from_buffer_async(&gpu_training.layer_inputs[seg_start], stream)
                 .ok()?;
         }
 
@@ -898,9 +895,7 @@ impl CudaTransformerTrainer {
                 // Input = layer_inputs[i], output = layer_inputs[i+1]
                 let li = &mut gpu_training.layer_inputs;
                 let (left, right) = li.split_at_mut(i + 1);
-                cuda_blocks[i]
-                    .forward(&left[i], &mut right[0], seq_len, stream)
-                    .ok()?;
+                cuda_blocks[i].forward(&left[i], &mut right[0], seq_len, stream).ok()?;
             }
         }
 
@@ -944,24 +939,31 @@ impl CudaTransformerTrainer {
             &self.gpu_training.logits_buf,
             &self.lm_head_weight_gpu,
             &mut self.gpu_training.lm_head_grad_hidden,
-            seq_len as u32, hidden_size as u32, vocab_size as u32,
+            seq_len as u32,
+            hidden_size as u32,
+            vocab_size as u32,
             stream,
-        ).ok()?;
+        )
+        .ok()?;
 
         gemm_backward_b(
             &self.gpu_training.norm_output,
             &self.gpu_training.logits_buf,
             &mut self.lm_head_grad_gpu,
-            seq_len as u32, hidden_size as u32, vocab_size as u32,
+            seq_len as u32,
+            hidden_size as u32,
+            vocab_size as u32,
             stream,
-        ).ok()?;
+        )
+        .ok()?;
 
         // Clip LM head weight gradient
         // KAIZEN-049: GPU norm reduction.
         // KAIZEN-051: No explicit sync needed — same stream ordering.
         // ALB-071: Always compute LM head grad norm for observability (R-004).
-        let lm_norm = squared_sum_cuda(&self.lm_head_grad_gpu, self.lm_head_grad_gpu.len() as u32, stream)
-            .unwrap_or(0.0);
+        let lm_norm =
+            squared_sum_cuda(&self.lm_head_grad_gpu, self.lm_head_grad_gpu.len() as u32, stream)
+                .unwrap_or(0.0);
         self.last_grad_norm = lm_norm; // R-004: capture for observability (now on unscaled grads)
         if let Some(max_norm) = max_grad_norm {
             let clip_scale = if lm_norm > max_norm { max_norm / lm_norm } else { 1.0 };
@@ -978,15 +980,24 @@ impl CudaTransformerTrainer {
             &self.gpu_training.lm_head_grad_hidden,
             &mut self.gpu_training.grad_buf_a,
             &mut self.gpu_training.grad_final_norm_weight,
-            seq_len as u32, hidden_size as u32, 1e-5_f32, stream,
-        ).ok()?;
+            seq_len as u32,
+            hidden_size as u32,
+            1e-5_f32,
+            stream,
+        )
+        .ok()?;
 
         // Clip final norm weight gradient
         // KAIZEN-051: No explicit sync needed — same stream ordering as LM head clip.
         if let Some(max_norm) = max_grad_norm {
-            let (scale, _) = Self::compute_clip_scale_with_norm(&self.gpu_training.grad_final_norm_weight, max_norm, stream);
+            let (scale, _) = Self::compute_clip_scale_with_norm(
+                &self.gpu_training.grad_final_norm_weight,
+                max_norm,
+                stream,
+            );
             let n = self.gpu_training.grad_final_norm_weight.len() as u32;
-            let _ = gradient_clip_cuda(&mut self.gpu_training.grad_final_norm_weight, scale, n, stream);
+            let _ =
+                gradient_clip_cuda(&mut self.gpu_training.grad_final_norm_weight, scale, n, stream);
         }
         self.profiler.end(StepProfiler::NORM_BWD);
 
@@ -1002,10 +1013,17 @@ impl CudaTransformerTrainer {
         } else {
             Self::run_nonblock_optimizer_step(
                 &mut self.gpu_training,
-                &mut self.lm_head_weight_gpu, &self.lm_head_grad_gpu,
-                &mut self.lm_head_m, &mut self.lm_head_v,
-                &mut self.final_norm_m, &mut self.final_norm_v,
-                lr, beta1, beta2, weight_decay, stream,
+                &mut self.lm_head_weight_gpu,
+                &self.lm_head_grad_gpu,
+                &mut self.lm_head_m,
+                &mut self.lm_head_v,
+                &mut self.final_norm_m,
+                &mut self.final_norm_v,
+                lr,
+                beta1,
+                beta2,
+                weight_decay,
+                stream,
             );
         }
 
@@ -1041,11 +1059,16 @@ impl CudaTransformerTrainer {
                     (&*grad_b_ptr, &mut *grad_a_ptr)
                 }
             };
-            self.cuda_blocks[layer_idx].backward(
-                &self.gpu_training.layer_inputs[layer_idx],
-                grad_output, grad_input, seq_len, stream,
-                &mut self.cuda_grad_workspace,
-            ).ok()?;
+            self.cuda_blocks[layer_idx]
+                .backward(
+                    &self.gpu_training.layer_inputs[layer_idx],
+                    grad_output,
+                    grad_input,
+                    seq_len,
+                    stream,
+                    &mut self.cuda_grad_workspace,
+                )
+                .ok()?;
 
             // KAIZEN-054: Per-block gradient clipping re-enabled via GPU-side norm.
             // squared_sum_cuda computes L2 norm on GPU (~1KB D2H per buffer, 9 buffers).
@@ -1065,7 +1088,9 @@ impl CudaTransformerTrainer {
                 stream.synchronize().ok()?;
                 if let Some(accum) = &mut self.grad_accum {
                     Self::download_workspace_to_accum(
-                        &self.cuda_grad_workspace, accum, layer_idx,
+                        &self.cuda_grad_workspace,
+                        accum,
+                        layer_idx,
                         &mut self.d2h_staging,
                     )?;
                 }
@@ -1074,7 +1099,13 @@ impl CudaTransformerTrainer {
                 let step = self.gpu_training.step;
                 let _ = self.cuda_blocks[layer_idx].optimizer_step(
                     &mut self.gpu_training.optimizer_states[layer_idx],
-                    step, lr, beta1, beta2, 1e-8, weight_decay, stream,
+                    step,
+                    lr,
+                    beta1,
+                    beta2,
+                    1e-8,
+                    weight_decay,
+                    stream,
                     &self.cuda_grad_workspace,
                 );
             }
@@ -1141,7 +1172,14 @@ impl CudaTransformerTrainer {
             lm_head_grad_gpu,
             lm_head_m,
             lm_head_v,
-            lr, beta1, beta2, 1e-8, weight_decay, step, n_lm, stream,
+            lr,
+            beta1,
+            beta2,
+            1e-8,
+            weight_decay,
+            step,
+            n_lm,
+            stream,
         );
 
         let n_norm = gpu_training.final_norm_weight.len() as u32;
@@ -1150,7 +1188,14 @@ impl CudaTransformerTrainer {
             &gpu_training.grad_final_norm_weight,
             final_norm_m,
             final_norm_v,
-            lr, beta1, beta2, 1e-8, weight_decay, step, n_norm, stream,
+            lr,
+            beta1,
+            beta2,
+            1e-8,
+            weight_decay,
+            step,
+            n_norm,
+            stream,
         );
     }
 
@@ -1225,21 +1270,54 @@ impl CudaTransformerTrainer {
 
             // Upload accumulated gradients to shared workspace
             unsafe {
-                self.cuda_grad_workspace.grad_w_q.copy_from_host_async(&bg.components[component::W_Q], stream).ok()?;
-                self.cuda_grad_workspace.grad_w_k.copy_from_host_async(&bg.components[component::W_K], stream).ok()?;
-                self.cuda_grad_workspace.grad_w_v.copy_from_host_async(&bg.components[component::W_V], stream).ok()?;
-                self.cuda_grad_workspace.grad_w_o.copy_from_host_async(&bg.components[component::W_O], stream).ok()?;
-                self.cuda_grad_workspace.grad_gate.copy_from_host_async(&bg.components[component::GATE], stream).ok()?;
-                self.cuda_grad_workspace.grad_up.copy_from_host_async(&bg.components[component::UP], stream).ok()?;
-                self.cuda_grad_workspace.grad_down.copy_from_host_async(&bg.components[component::DOWN], stream).ok()?;
-                self.cuda_grad_workspace.grad_input_norm.copy_from_host_async(&bg.components[component::INPUT_NORM], stream).ok()?;
-                self.cuda_grad_workspace.grad_post_attn_norm.copy_from_host_async(&bg.components[component::POST_ATTN_NORM], stream).ok()?;
+                self.cuda_grad_workspace
+                    .grad_w_q
+                    .copy_from_host_async(&bg.components[component::W_Q], stream)
+                    .ok()?;
+                self.cuda_grad_workspace
+                    .grad_w_k
+                    .copy_from_host_async(&bg.components[component::W_K], stream)
+                    .ok()?;
+                self.cuda_grad_workspace
+                    .grad_w_v
+                    .copy_from_host_async(&bg.components[component::W_V], stream)
+                    .ok()?;
+                self.cuda_grad_workspace
+                    .grad_w_o
+                    .copy_from_host_async(&bg.components[component::W_O], stream)
+                    .ok()?;
+                self.cuda_grad_workspace
+                    .grad_gate
+                    .copy_from_host_async(&bg.components[component::GATE], stream)
+                    .ok()?;
+                self.cuda_grad_workspace
+                    .grad_up
+                    .copy_from_host_async(&bg.components[component::UP], stream)
+                    .ok()?;
+                self.cuda_grad_workspace
+                    .grad_down
+                    .copy_from_host_async(&bg.components[component::DOWN], stream)
+                    .ok()?;
+                self.cuda_grad_workspace
+                    .grad_input_norm
+                    .copy_from_host_async(&bg.components[component::INPUT_NORM], stream)
+                    .ok()?;
+                self.cuda_grad_workspace
+                    .grad_post_attn_norm
+                    .copy_from_host_async(&bg.components[component::POST_ATTN_NORM], stream)
+                    .ok()?;
             }
 
             // Run optimizer step with uploaded averaged gradients
             let _ = self.cuda_blocks[layer_idx].optimizer_step(
                 &mut self.gpu_training.optimizer_states[layer_idx],
-                step, lr, beta1, beta2, 1e-8, weight_decay, stream,
+                step,
+                lr,
+                beta1,
+                beta2,
+                1e-8,
+                weight_decay,
+                stream,
                 &self.cuda_grad_workspace,
             );
         }
@@ -1254,13 +1332,22 @@ impl CudaTransformerTrainer {
             &self.lm_head_grad_gpu,
             &mut self.lm_head_m,
             &mut self.lm_head_v,
-            lr, beta1, beta2, 1e-8, weight_decay, step, n_lm, stream,
+            lr,
+            beta1,
+            beta2,
+            1e-8,
+            weight_decay,
+            step,
+            n_lm,
+            stream,
         );
 
         // Upload and optimize final norm
         unsafe {
-            self.gpu_training.grad_final_norm_weight
-                .copy_from_host_async(&accum.final_norm_grad, stream).ok()?;
+            self.gpu_training
+                .grad_final_norm_weight
+                .copy_from_host_async(&accum.final_norm_grad, stream)
+                .ok()?;
         }
         let n_norm = self.gpu_training.final_norm_weight.len() as u32;
         let _ = adamw_step_cuda(
@@ -1268,7 +1355,14 @@ impl CudaTransformerTrainer {
             &self.gpu_training.grad_final_norm_weight,
             &mut self.final_norm_m,
             &mut self.final_norm_v,
-            lr, beta1, beta2, 1e-8, weight_decay, step, n_norm, stream,
+            lr,
+            beta1,
+            beta2,
+            1e-8,
+            weight_decay,
+            step,
+            n_norm,
+            stream,
         );
 
         stream.synchronize().ok()?;
@@ -1309,14 +1403,9 @@ impl CudaTransformerTrainer {
                 sq_sum.sqrt() as f32
             }
         };
-        let scale = if grad_norm > max_norm {
-            max_norm / grad_norm
-        } else {
-            1.0
-        };
+        let scale = if grad_norm > max_norm { max_norm / grad_norm } else { 1.0 };
         (scale, grad_norm)
     }
-
 
     /// Download embedding gradient from GPU, clip, and scatter-add into CPU weight.
     ///
@@ -1339,7 +1428,11 @@ impl CudaTransformerTrainer {
         let grad_a_ptr: *const GpuBuffer<f32> = &self.gpu_training.grad_buf_a;
         let grad_b_ptr: *const GpuBuffer<f32> = &self.gpu_training.grad_buf_b;
         let embed_grad_buf = unsafe {
-            if grad_output_is_a { &*grad_a_ptr } else { &*grad_b_ptr }
+            if grad_output_is_a {
+                &*grad_a_ptr
+            } else {
+                &*grad_b_ptr
+            }
         };
         let mut embed_grad_data = self.cuda_trainer.download(embed_grad_buf).ok()?;
 
@@ -1430,8 +1523,7 @@ impl CudaTransformerTrainer {
 
         if self.accumulated_batches == 0 {
             // Zero embedding gradients at start of accumulation window
-            self.embed_optimizer
-                .zero_grad_refs(&mut vec![&mut self.model.embed_tokens.weight]);
+            self.embed_optimizer.zero_grad_refs(&mut vec![&mut self.model.embed_tokens.weight]);
         }
 
         let mut total_loss = 0.0;
@@ -1459,11 +1551,7 @@ impl CudaTransformerTrainer {
             }
         }
 
-        let avg_loss = if valid_count > 0 {
-            total_loss / valid_count as f32
-        } else {
-            0.0
-        };
+        let avg_loss = if valid_count > 0 { total_loss / valid_count as f32 } else { 0.0 };
 
         self.accumulated_loss += avg_loss / self.config.accumulation_steps as f32;
         self.accumulated_batches += 1;
@@ -1489,18 +1577,27 @@ impl CudaTransformerTrainer {
         let mut total_loss = 0.0;
         let mut valid_count = 0;
         for i in 0..batch.batch_size {
-            if let Some(loss) = self.eval_single_sequence(batch, i, max_sl, hidden_size, vocab_size) {
+            if let Some(loss) = self.eval_single_sequence(batch, i, max_sl, hidden_size, vocab_size)
+            {
                 total_loss += loss;
                 valid_count += 1;
             }
         }
-        if valid_count > 0 { total_loss / valid_count as f32 } else { 0.0 }
+        if valid_count > 0 {
+            total_loss / valid_count as f32
+        } else {
+            0.0
+        }
     }
 
     /// Evaluate a single sequence from a batch. Returns None if invalid.
     fn eval_single_sequence(
-        &mut self, batch: &LMBatch, i: usize, max_sl: usize,
-        hidden_size: usize, vocab_size: usize,
+        &mut self,
+        batch: &LMBatch,
+        i: usize,
+        max_sl: usize,
+        hidden_size: usize,
+        vocab_size: usize,
     ) -> Option<f32> {
         let input_ids = batch.get_input(i)?;
         let target_ids = batch.get_target(i)?;
@@ -1518,8 +1615,13 @@ impl CudaTransformerTrainer {
             vocab_size as u32,
             scale,
             stream,
-        ).ok()?;
-        if loss.is_finite() { Some(loss) } else { None }
+        )
+        .ok()?;
+        if loss.is_finite() {
+            Some(loss)
+        } else {
+            None
+        }
     }
 
     /// Train for one epoch over batches.
@@ -1576,7 +1678,9 @@ impl CudaTransformerTrainer {
         let hidden_size = mc.hidden_size;
         let kv_hidden = mc.num_kv_heads * mc.head_dim();
         let block_sizes = super::grad_accumulator::PerBlockGradientAccumulator::compute_block_sizes(
-            hidden_size, kv_hidden, mc.intermediate_size,
+            hidden_size,
+            kv_hidden,
+            mc.intermediate_size,
         );
         self.grad_accum = Some(super::grad_accumulator::PerBlockGradientAccumulator::new(
             self.cuda_blocks.len(),
@@ -1596,8 +1700,7 @@ impl CudaTransformerTrainer {
         }
 
         if self.accumulated_batches == 0 {
-            self.embed_optimizer
-                .zero_grad_refs(&mut vec![&mut self.model.embed_tokens.weight]);
+            self.embed_optimizer.zero_grad_refs(&mut vec![&mut self.model.embed_tokens.weight]);
         }
 
         let mut total_loss = 0.0;
@@ -1637,12 +1740,16 @@ impl CudaTransformerTrainer {
     }
 
     /// Get a reference to the gradient accumulator (for DDP AllReduce).
-    pub(crate) fn grad_accum_ref(&self) -> Option<&super::grad_accumulator::PerBlockGradientAccumulator> {
+    pub(crate) fn grad_accum_ref(
+        &self,
+    ) -> Option<&super::grad_accumulator::PerBlockGradientAccumulator> {
         self.grad_accum.as_ref()
     }
 
     /// Get a mutable reference to the gradient accumulator (for DDP AllReduce).
-    pub(crate) fn grad_accum_mut(&mut self) -> Option<&mut super::grad_accumulator::PerBlockGradientAccumulator> {
+    pub(crate) fn grad_accum_mut(
+        &mut self,
+    ) -> Option<&mut super::grad_accumulator::PerBlockGradientAccumulator> {
         self.grad_accum.as_mut()
     }
 
@@ -1658,10 +1765,7 @@ impl CudaTransformerTrainer {
 
     /// Set CPU embedding gradient from AllReduced flat Vec.
     pub(crate) fn set_embed_grad(&mut self, grad: Vec<f32>) {
-        self.model
-            .embed_tokens
-            .weight
-            .set_grad(ndarray::Array1::from(grad));
+        self.model.embed_tokens.weight.set_grad(ndarray::Array1::from(grad));
     }
 
     /// Returns true if max_steps has been reached.
@@ -1750,8 +1854,7 @@ impl CudaTransformerTrainer {
                 layer.ffn.w_up = Tensor::from_vec(weights.w_up, false);
                 layer.ffn.w_down = Tensor::from_vec(weights.w_down, false);
 
-                layer.input_norm.weight =
-                    Tensor::from_vec(weights.input_norm_weight, false);
+                layer.input_norm.weight = Tensor::from_vec(weights.input_norm_weight, false);
                 layer.post_attn_norm.weight =
                     Tensor::from_vec(weights.post_attn_norm_weight, false);
             }
@@ -1815,9 +1918,7 @@ impl CudaTransformerTrainer {
 
         for layer in 0..num_layers {
             names.push(format!("model.layers.{layer}.input_layernorm.weight"));
-            names.push(format!(
-                "model.layers.{layer}.post_attention_layernorm.weight"
-            ));
+            names.push(format!("model.layers.{layer}.post_attention_layernorm.weight"));
             names.push(format!("model.layers.{layer}.self_attn.q_proj.weight"));
             names.push(format!("model.layers.{layer}.self_attn.k_proj.weight"));
             names.push(format!("model.layers.{layer}.self_attn.v_proj.weight"));
@@ -1877,20 +1978,15 @@ impl CudaTransformerTrainer {
         }
 
         // Snapshot raw Vec<f32> data — Send-safe (Tensor contains Rc, not Send)
-        let param_data: Vec<(String, Vec<f32>)> = names
-            .into_iter()
-            .zip(model_params)
-            .map(|(n, t)| (n, t.data().to_vec()))
-            .collect();
+        let param_data: Vec<(String, Vec<f32>)> =
+            names.into_iter().zip(model_params).map(|(n, t)| (n, t.data().to_vec())).collect();
 
         let name = name.to_string();
         let architecture = architecture.to_string();
 
         Box::new(move |path: &std::path::Path| {
-            let params: Vec<(String, Tensor)> = param_data
-                .into_iter()
-                .map(|(n, d)| (n, Tensor::from_vec(d, false)))
-                .collect();
+            let params: Vec<(String, Tensor)> =
+                param_data.into_iter().map(|(n, d)| (n, Tensor::from_vec(d, false))).collect();
             let metadata = ModelMetadata::new(&name, &architecture);
             let model = Model::new(metadata, params);
             let config = SaveConfig::new(ModelFormat::SafeTensors);
@@ -1909,11 +2005,15 @@ impl CudaTransformerTrainer {
     /// states remain on-device (D2H for 20 buffers × N blocks is deferred).
     pub fn save_optimizer_state(&self, dir: &std::path::Path) -> crate::Result<()> {
         let path = dir.join("optimizer_state.json");
-        let m_data: Vec<Option<Vec<f32>>> = self.embed_optimizer.first_moments()
+        let m_data: Vec<Option<Vec<f32>>> = self
+            .embed_optimizer
+            .first_moments()
             .iter()
             .map(|opt| opt.as_ref().map(|a| a.to_vec()))
             .collect();
-        let v_data: Vec<Option<Vec<f32>>> = self.embed_optimizer.second_moments()
+        let v_data: Vec<Option<Vec<f32>>> = self
+            .embed_optimizer
+            .second_moments()
             .iter()
             .map(|opt| opt.as_ref().map(|a| a.to_vec()))
             .collect();
@@ -1923,10 +2023,12 @@ impl CudaTransformerTrainer {
             "m": m_data,
             "v": v_data,
         });
-        let json_str = serde_json::to_string(&state)
-            .map_err(|e| crate::error::Error::ConfigError(format!("serialize optimizer state: {}", e)))?;
-        std::fs::write(&path, json_str)
-            .map_err(|e| crate::error::Error::ConfigError(format!("write optimizer state: {}", e)))?;
+        let json_str = serde_json::to_string(&state).map_err(|e| {
+            crate::error::Error::ConfigError(format!("serialize optimizer state: {}", e))
+        })?;
+        std::fs::write(&path, json_str).map_err(|e| {
+            crate::error::Error::ConfigError(format!("write optimizer state: {}", e))
+        })?;
         Ok(())
     }
 
@@ -1965,9 +2067,7 @@ fn restore_moment_buffers(
     let Some(arr) = json_arr.as_array() else { return };
     for (idx, val) in arr.iter().enumerate() {
         let Some(inner) = val.as_array() else { continue };
-        let floats: Vec<f32> = inner.iter()
-            .filter_map(|v| v.as_f64().map(|f| f as f32))
-            .collect();
+        let floats: Vec<f32> = inner.iter().filter_map(|v| v.as_f64().map(|f| f as f32)).collect();
         if !floats.is_empty() {
             set_fn(idx, ndarray::Array1::from_vec(floats));
         }
@@ -1981,9 +2081,7 @@ pub struct CudaTransformerTrainer;
 
 #[cfg(not(feature = "cuda"))]
 impl CudaTransformerTrainer {
-    pub fn new(
-        _config: super::config::TransformerTrainConfig,
-    ) -> crate::Result<Self> {
+    pub fn new(_config: super::config::TransformerTrainConfig) -> crate::Result<Self> {
         Err(crate::error::Error::ConfigError(
             "CUDA not available (compiled without cuda feature)".into(),
         ))

--- a/src/train/transformer_trainer/distributed_checkpoint.rs
+++ b/src/train/transformer_trainer/distributed_checkpoint.rs
@@ -48,12 +48,7 @@ pub struct DistributedCheckpointCoordinator {
 impl DistributedCheckpointCoordinator {
     /// Create a new coordinator.
     pub fn new(world_size: usize) -> Self {
-        Self {
-            phase: CheckpointPhase::Training,
-            acks_received: 0,
-            world_size,
-            checkpoint_step: 0,
-        }
+        Self { phase: CheckpointPhase::Training, acks_received: 0, world_size, checkpoint_step: 0 }
     }
 
     /// Request a checkpoint save at the given step.
@@ -157,11 +152,7 @@ pub fn hash_weights(weights: &[f32]) -> [u8; 32] {
 ///
 /// Follows the `save_interval` logic from the training config,
 /// accounting for the distributed checkpoint overhead.
-pub fn should_save_checkpoint(
-    step: usize,
-    save_interval: usize,
-    max_steps: Option<usize>,
-) -> bool {
+pub fn should_save_checkpoint(step: usize, save_interval: usize, max_steps: Option<usize>) -> bool {
     if save_interval == 0 {
         return false;
     }
@@ -206,7 +197,7 @@ mod tests {
         // Workers acknowledge
         assert!(!coord.worker_ready()); // 1 of 3
         assert!(!coord.worker_ready()); // 2 of 3
-        assert!(coord.worker_ready());  // 3 of 3 — barrier complete
+        assert!(coord.worker_ready()); // 3 of 3 — barrier complete
         assert_eq!(coord.phase(), CheckpointPhase::WeightsSynced);
 
         // Write

--- a/src/train/transformer_trainer/distributed_trainer.rs
+++ b/src/train/transformer_trainer/distributed_trainer.rs
@@ -61,27 +61,13 @@ pub enum DistributedComm {
 #[derive(Debug)]
 pub enum GradientMessage {
     /// Per-block gradient from a worker
-    BlockGradient {
-        block_idx: usize,
-        gradients: Vec<f32>,
-        component_sizes: Vec<u32>,
-    },
+    BlockGradient { block_idx: usize, gradients: Vec<f32>, component_sizes: Vec<u32> },
     /// Averaged per-block gradient from coordinator
-    AveragedBlockGradient {
-        block_idx: usize,
-        gradients: Vec<f32>,
-        component_sizes: Vec<u32>,
-    },
+    AveragedBlockGradient { block_idx: usize, gradients: Vec<f32>, component_sizes: Vec<u32> },
     /// Non-block gradient (LM head, final norm, embedding)
-    NonBlockGradient {
-        component: u8,
-        gradients: Vec<f32>,
-    },
+    NonBlockGradient { component: u8, gradients: Vec<f32> },
     /// Averaged non-block gradient
-    AveragedNonBlockGradient {
-        component: u8,
-        gradients: Vec<f32>,
-    },
+    AveragedNonBlockGradient { component: u8, gradients: Vec<f32> },
     /// Synchronization barrier
     Barrier,
 }
@@ -133,12 +119,7 @@ impl DistributedCudaTrainer {
         // DDP always needs grad accum buffers for CPU-side AllReduce
         trainer.ensure_grad_accum();
 
-        Self {
-            trainer,
-            comm,
-            dist_config,
-            step: 0,
-        }
+        Self { trainer, comm, dist_config, step: 0 }
     }
 
     /// DDP training step: forward+backward → AllReduce → optimizer.
@@ -219,17 +200,9 @@ impl DistributedCudaTrainer {
                 let flat = accum.block_grads[block_idx].flatten();
                 let sizes = accum.block_grads[block_idx].component_sizes_u32();
                 client
-                    .send_block_gradient(
-                        step,
-                        block_idx as u32,
-                        num_blocks as u32,
-                        flat,
-                        sizes,
-                    )
+                    .send_block_gradient(step, block_idx as u32, num_blocks as u32, flat, sizes)
                     .expect("block gradient send failed");
-                let avg = client
-                    .receive_averaged_block()
-                    .expect("block gradient receive failed");
+                let avg = client.receive_averaged_block().expect("block gradient receive failed");
                 accum.block_grads[block_idx] =
                     BlockGradientSet::from_flat(&avg.gradients, &avg.component_sizes);
             }
@@ -241,12 +214,8 @@ impl DistributedCudaTrainer {
 
             // LM head (component=0)
             let lm_grad = accum.lm_head_grad.clone();
-            client
-                .send_non_block_gradient(step, 0, lm_grad)
-                .expect("lm_head gradient send failed");
-            let avg = client
-                .receive_averaged_non_block()
-                .expect("lm_head gradient receive failed");
+            client.send_non_block_gradient(step, 0, lm_grad).expect("lm_head gradient send failed");
+            let avg = client.receive_averaged_non_block().expect("lm_head gradient receive failed");
             accum.lm_head_grad = avg.gradients;
 
             // Final norm (component=1)
@@ -254,9 +223,8 @@ impl DistributedCudaTrainer {
             client
                 .send_non_block_gradient(step, 1, norm_grad)
                 .expect("final_norm gradient send failed");
-            let avg = client
-                .receive_averaged_non_block()
-                .expect("final_norm gradient receive failed");
+            let avg =
+                client.receive_averaged_non_block().expect("final_norm gradient receive failed");
             accum.final_norm_grad = avg.gradients;
 
             // Prevent re-averaging in gpu_optimizer_from_accum
@@ -269,9 +237,8 @@ impl DistributedCudaTrainer {
             client
                 .send_non_block_gradient(step, 2, embed_grad)
                 .expect("embedding gradient send failed");
-            let avg = client
-                .receive_averaged_non_block()
-                .expect("embedding gradient receive failed");
+            let avg =
+                client.receive_averaged_non_block().expect("embedding gradient receive failed");
             trainer.set_embed_grad(avg.gradients);
         }
     }
@@ -301,9 +268,7 @@ impl DistributedCudaTrainer {
 
                 match rx.recv().expect("channel recv failed") {
                     GradientMessage::AveragedBlockGradient {
-                        gradients,
-                        component_sizes,
-                        ..
+                        gradients, component_sizes, ..
                     } => {
                         accum.block_grads[block_idx] =
                             BlockGradientSet::from_flat(&gradients, &component_sizes);
@@ -319,11 +284,8 @@ impl DistributedCudaTrainer {
 
             // LM head
             let lm_grad = accum.lm_head_grad.clone();
-            tx.send(GradientMessage::NonBlockGradient {
-                component: 0,
-                gradients: lm_grad,
-            })
-            .expect("channel send failed");
+            tx.send(GradientMessage::NonBlockGradient { component: 0, gradients: lm_grad })
+                .expect("channel send failed");
             match rx.recv().expect("channel recv failed") {
                 GradientMessage::AveragedNonBlockGradient { gradients, .. } => {
                     accum.lm_head_grad = gradients;
@@ -333,11 +295,8 @@ impl DistributedCudaTrainer {
 
             // Final norm
             let norm_grad = accum.final_norm_grad.clone();
-            tx.send(GradientMessage::NonBlockGradient {
-                component: 1,
-                gradients: norm_grad,
-            })
-            .expect("channel send failed");
+            tx.send(GradientMessage::NonBlockGradient { component: 1, gradients: norm_grad })
+                .expect("channel send failed");
             match rx.recv().expect("channel recv failed") {
                 GradientMessage::AveragedNonBlockGradient { gradients, .. } => {
                     accum.final_norm_grad = gradients;
@@ -351,11 +310,8 @@ impl DistributedCudaTrainer {
         // Phase 3: Embedding AllReduce
         {
             let embed_grad = trainer.embed_grad_vec().unwrap_or_default();
-            tx.send(GradientMessage::NonBlockGradient {
-                component: 2,
-                gradients: embed_grad,
-            })
-            .expect("channel send failed");
+            tx.send(GradientMessage::NonBlockGradient { component: 2, gradients: embed_grad })
+                .expect("channel send failed");
             match rx.recv().expect("channel recv failed") {
                 GradientMessage::AveragedNonBlockGradient { gradients, .. } => {
                     trainer.set_embed_grad(gradients);
@@ -470,12 +426,8 @@ mod tests {
         assert_eq!(shard1, vec![1, 4]);
         assert_eq!(shard2, vec![2, 5]);
 
-        let mut all: Vec<usize> = shard0
-            .iter()
-            .chain(shard1.iter())
-            .chain(shard2.iter())
-            .copied()
-            .collect();
+        let mut all: Vec<usize> =
+            shard0.iter().chain(shard1.iter()).chain(shard2.iter()).copied().collect();
         all.sort_unstable();
         assert_eq!(all, (0..7).collect::<Vec<_>>());
     }

--- a/src/train/transformer_trainer/elastic.rs
+++ b/src/train/transformer_trainer/elastic.rs
@@ -110,12 +110,7 @@ impl ElasticCoordinator {
     /// Add a new worker to the pool.
     ///
     /// Returns the assigned worker ID, or None if pool is full.
-    pub fn add_worker(
-        &mut self,
-        node_id: String,
-        gpu_count: u32,
-        backend: String,
-    ) -> Option<u32> {
+    pub fn add_worker(&mut self, node_id: String, gpu_count: u32, backend: String) -> Option<u32> {
         if self.active_count() >= self.max_workers {
             return None;
         }
@@ -265,11 +260,7 @@ impl ElasticCoordinator {
                 } else {
                     remainder * (shard_size + 1) + (i - remainder) * shard_size
                 };
-                let end = if i < remainder {
-                    start + shard_size + 1
-                } else {
-                    start + shard_size
-                };
+                let end = if i < remainder { start + shard_size + 1 } else { start + shard_size };
                 (wid, start, end)
             })
             .collect()

--- a/src/train/transformer_trainer/grad_accumulator.rs
+++ b/src/train/transformer_trainer/grad_accumulator.rs
@@ -100,7 +100,9 @@ impl BlockGradientSet {
     /// Zero all gradient components (reuse buffers).
     pub fn zero(&mut self) {
         for comp in &mut self.components {
-            for x in comp.iter_mut() { *x = 0.0; }
+            for x in comp.iter_mut() {
+                *x = 0.0;
+            }
         }
     }
 
@@ -176,9 +178,7 @@ impl PerBlockGradientAccumulator {
         vocab_size: usize,
         hidden_size: usize,
     ) -> Self {
-        let block_grads = (0..num_blocks)
-            .map(|_| BlockGradientSet::zeroed(&block_sizes))
-            .collect();
+        let block_grads = (0..num_blocks).map(|_| BlockGradientSet::zeroed(&block_sizes)).collect();
 
         Self {
             block_grads,
@@ -202,15 +202,15 @@ impl PerBlockGradientAccumulator {
         intermediate_size: usize,
     ) -> [usize; BLOCK_GRAD_COMPONENTS] {
         [
-            hidden_size * hidden_size,         // w_q
-            hidden_size * kv_hidden_size,      // w_k
-            hidden_size * kv_hidden_size,      // w_v
-            hidden_size * hidden_size,         // w_o
-            hidden_size * intermediate_size,   // gate
-            hidden_size * intermediate_size,   // up
-            intermediate_size * hidden_size,   // down
-            hidden_size,                       // input_norm
-            hidden_size,                       // post_attn_norm
+            hidden_size * hidden_size,       // w_q
+            hidden_size * kv_hidden_size,    // w_k
+            hidden_size * kv_hidden_size,    // w_v
+            hidden_size * hidden_size,       // w_o
+            hidden_size * intermediate_size, // gate
+            hidden_size * intermediate_size, // up
+            intermediate_size * hidden_size, // down
+            hidden_size,                     // input_norm
+            hidden_size,                     // post_attn_norm
         ]
     }
 
@@ -337,13 +337,13 @@ mod tests {
     fn test_accumulator_compute_block_sizes_350m() {
         // 350M: H=1024, num_heads=16, num_kv_heads=4, kv_dim=256, I=4096
         let sizes = PerBlockGradientAccumulator::compute_block_sizes(1024, 256, 4096);
-        assert_eq!(sizes[component::W_Q], 1024 * 1024);       // 1M
-        assert_eq!(sizes[component::W_K], 1024 * 256);        // 256K
-        assert_eq!(sizes[component::W_V], 1024 * 256);        // 256K
-        assert_eq!(sizes[component::W_O], 1024 * 1024);       // 1M
-        assert_eq!(sizes[component::GATE], 1024 * 4096);      // 4M
-        assert_eq!(sizes[component::UP], 1024 * 4096);        // 4M
-        assert_eq!(sizes[component::DOWN], 4096 * 1024);      // 4M
+        assert_eq!(sizes[component::W_Q], 1024 * 1024); // 1M
+        assert_eq!(sizes[component::W_K], 1024 * 256); // 256K
+        assert_eq!(sizes[component::W_V], 1024 * 256); // 256K
+        assert_eq!(sizes[component::W_O], 1024 * 1024); // 1M
+        assert_eq!(sizes[component::GATE], 1024 * 4096); // 4M
+        assert_eq!(sizes[component::UP], 1024 * 4096); // 4M
+        assert_eq!(sizes[component::DOWN], 4096 * 1024); // 4M
         assert_eq!(sizes[component::INPUT_NORM], 1024);
         assert_eq!(sizes[component::POST_ATTN_NORM], 1024);
     }

--- a/src/train/transformer_trainer/mod.rs
+++ b/src/train/transformer_trainer/mod.rs
@@ -12,8 +12,8 @@ pub mod elastic;
 pub mod grad_accumulator;
 pub mod pipeline;
 pub mod sequence_parallel;
-pub mod tensor_parallel;
 pub mod step_profiler;
+pub mod tensor_parallel;
 mod trainer;
 mod utils;
 pub mod zero;
@@ -26,14 +26,14 @@ pub use batch::LMBatch;
 pub use config::{
     DistributedBackend, DistributedRole, DistributedTrainConfig, TransformerTrainConfig,
 };
-pub use grad_accumulator::{BlockGradientSet, PerBlockGradientAccumulator};
+pub use cuda_trainer::CudaTransformerTrainer;
 pub use distributed_checkpoint::DistributedCheckpointCoordinator;
+pub use distributed_trainer::shard_batches;
 #[cfg(feature = "cuda")]
 #[allow(unused_imports)]
-pub use distributed_trainer::{DistributedCudaTrainer, DistributedComm, GradientMessage};
-pub use distributed_trainer::shard_batches;
-pub use cuda_trainer::CudaTransformerTrainer;
+pub use distributed_trainer::{DistributedComm, DistributedCudaTrainer, GradientMessage};
 pub use elastic::ElasticCoordinator;
+pub use grad_accumulator::{BlockGradientSet, PerBlockGradientAccumulator};
 pub use pipeline::{PipelineAction, PipelineActivationBuffer, PipelineStage};
 pub use sequence_parallel::{
     CausalMaskType, RingAttentionSchedule, SequenceParallelConfig, SpCommCost,

--- a/src/train/transformer_trainer/pipeline.rs
+++ b/src/train/transformer_trainer/pipeline.rs
@@ -206,17 +206,25 @@ impl PipelineActivationBuffer {
 
     /// Store forward activation for a micro-batch.
     pub fn store_activation(&mut self, micro_batch: usize, activation: Vec<f32>) {
-        assert_eq!(activation.len(), self.activation_size,
+        assert_eq!(
+            activation.len(),
+            self.activation_size,
             "activation size mismatch: expected {}, got {}",
-            self.activation_size, activation.len());
+            self.activation_size,
+            activation.len()
+        );
         self.forward_activations[micro_batch] = activation;
     }
 
     /// Store backward gradient for a micro-batch.
     pub fn store_gradient(&mut self, micro_batch: usize, gradient: Vec<f32>) {
-        assert_eq!(gradient.len(), self.activation_size,
+        assert_eq!(
+            gradient.len(),
+            self.activation_size,
             "gradient size mismatch: expected {}, got {}",
-            self.activation_size, gradient.len());
+            self.activation_size,
+            gradient.len()
+        );
         self.backward_gradients[micro_batch] = gradient;
     }
 
@@ -311,16 +319,20 @@ mod tests {
 
         // Count forwards and backwards
         let fwd_count = schedule.iter().filter(|a| matches!(a, PipelineAction::Forward(_))).count();
-        let bwd_count = schedule.iter().filter(|a| matches!(a, PipelineAction::Backward(_))).count();
+        let bwd_count =
+            schedule.iter().filter(|a| matches!(a, PipelineAction::Backward(_))).count();
 
         assert_eq!(fwd_count, 4, "should have 4 forwards");
         assert_eq!(bwd_count, 4, "should have 4 backwards");
 
         // All micro-batches covered
-        let mut fwd_ids: Vec<_> = schedule.iter().filter_map(|a| match a {
-            PipelineAction::Forward(id) => Some(*id),
-            _ => None,
-        }).collect();
+        let mut fwd_ids: Vec<_> = schedule
+            .iter()
+            .filter_map(|a| match a {
+                PipelineAction::Forward(id) => Some(*id),
+                _ => None,
+            })
+            .collect();
         fwd_ids.sort_unstable();
         assert_eq!(fwd_ids, vec![0, 1, 2, 3]);
     }

--- a/src/train/transformer_trainer/sequence_parallel.rs
+++ b/src/train/transformer_trainer/sequence_parallel.rs
@@ -71,14 +71,7 @@ impl SequenceParallelConfig {
 
         let head_dim = hidden_size / num_heads;
 
-        Self {
-            sp_rank,
-            sp_size,
-            full_seq_len,
-            hidden_size,
-            num_heads,
-            head_dim,
-        }
+        Self { sp_rank, sp_size, full_seq_len, hidden_size, num_heads, head_dim }
     }
 
     /// Local sequence length on this GPU.
@@ -153,12 +146,7 @@ impl RingAttentionSchedule {
             // After `step` rotations, we have K,V from rank (rank - step - 1) mod N
             let kv_chunk_source = (rank + world_size - step - 1) % world_size;
 
-            steps.push(RingStep {
-                step,
-                send_to,
-                recv_from,
-                kv_chunk_source,
-            });
+            steps.push(RingStep { step, send_to, recv_from, kv_chunk_source });
         }
 
         Self { steps, rank, world_size }
@@ -222,11 +210,7 @@ impl SpCommCost {
         let kv_bytes_per_send =
             2 * local_seq_len * head_dim * num_kv_heads * std::mem::size_of::<f32>();
 
-        Self {
-            kv_bytes_per_send,
-            ring_steps: sp_size - 1,
-            num_blocks,
-        }
+        Self { kv_bytes_per_send, ring_steps: sp_size - 1, num_blocks }
     }
 
     /// Total bytes communicated per training step.

--- a/src/train/transformer_trainer/step_profiler.rs
+++ b/src/train/transformer_trainer/step_profiler.rs
@@ -42,8 +42,17 @@ const OPT: usize = 10;
 const NUM_PHASES: usize = 11;
 
 const PHASE_NAMES: [&str; NUM_PHASES] = [
-    "embed", "h2d", "forward", "norm_lm", "loss",
-    "grad_h2d", "lm_bwd", "norm_bwd", "blk_bwd", "embed_bwd", "opt",
+    "embed",
+    "h2d",
+    "forward",
+    "norm_lm",
+    "loss",
+    "grad_h2d",
+    "lm_bwd",
+    "norm_bwd",
+    "blk_bwd",
+    "embed_bwd",
+    "opt",
 ];
 
 /// Per-step timing accumulator.
@@ -152,7 +161,11 @@ impl StepProfiler {
         let total_us = self.total_wall.as_micros() as f64;
         let avg_step_us = total_us / self.step_count as f64;
 
-        println!("\n┌─ Step Profiler ({} steps, avg {:.1} ms/step) ─┐", self.step_count, avg_step_us / 1000.0);
+        println!(
+            "\n┌─ Step Profiler ({} steps, avg {:.1} ms/step) ─┐",
+            self.step_count,
+            avg_step_us / 1000.0
+        );
         println!("│ {:>10} │ {:>8} │ {:>6} │ {:>8} │", "phase", "total_ms", "pct", "avg_ms");
         println!("│ {:-<10} │ {:-<8} │ {:-<6} │ {:-<8} │", "", "", "", "");
 
@@ -167,21 +180,39 @@ impl StepProfiler {
         }
 
         let unaccounted = self.total_wall.saturating_sub(accounted);
-        let unaccounted_pct = if total_us > 0.0 { unaccounted.as_micros() as f64 / total_us * 100.0 } else { 0.0 };
-        println!("│ {:>10} │ {:>8.1} │ {:>5.1}% │ {:>8.2} │", "other", unaccounted.as_micros() as f64 / 1000.0, unaccounted_pct, unaccounted.as_micros() as f64 / 1000.0 / self.step_count as f64);
+        let unaccounted_pct =
+            if total_us > 0.0 { unaccounted.as_micros() as f64 / total_us * 100.0 } else { 0.0 };
+        println!(
+            "│ {:>10} │ {:>8.1} │ {:>5.1}% │ {:>8.2} │",
+            "other",
+            unaccounted.as_micros() as f64 / 1000.0,
+            unaccounted_pct,
+            unaccounted.as_micros() as f64 / 1000.0 / self.step_count as f64
+        );
 
-        println!("│ {:>10} │ {:>8.1} │ {:>5}  │ {:>8.2} │", "TOTAL", total_us / 1000.0, "100%", avg_step_us / 1000.0);
+        println!(
+            "│ {:>10} │ {:>8.1} │ {:>5}  │ {:>8.2} │",
+            "TOTAL",
+            total_us / 1000.0,
+            "100%",
+            avg_step_us / 1000.0
+        );
         println!("└────────────┴──────────┴────────┴──────────┘");
 
         // Percentiles for step wall-clock
         if self.step_durations.len() >= 10 {
-            let mut sorted: Vec<u128> = self.step_durations.iter().map(std::time::Duration::as_micros).collect();
+            let mut sorted: Vec<u128> =
+                self.step_durations.iter().map(std::time::Duration::as_micros).collect();
             sorted.sort_unstable();
             let p50 = sorted[sorted.len() / 2];
             let p95 = sorted[sorted.len() * 95 / 100];
             let p99 = sorted[sorted.len() * 99 / 100];
-            println!("  Step latency: p50={:.1}ms p95={:.1}ms p99={:.1}ms",
-                p50 as f64 / 1000.0, p95 as f64 / 1000.0, p99 as f64 / 1000.0);
+            println!(
+                "  Step latency: p50={:.1}ms p95={:.1}ms p99={:.1}ms",
+                p50 as f64 / 1000.0,
+                p95 as f64 / 1000.0,
+                p99 as f64 / 1000.0
+            );
         }
     }
 

--- a/src/train/transformer_trainer/tensor_parallel.rs
+++ b/src/train/transformer_trainer/tensor_parallel.rs
@@ -86,15 +86,7 @@ impl TensorParallelConfig {
 
         let head_dim = hidden_size / num_heads;
 
-        Self {
-            tp_rank,
-            tp_size,
-            hidden_size,
-            intermediate_size,
-            num_heads,
-            num_kv_heads,
-            head_dim,
-        }
+        Self { tp_rank, tp_size, hidden_size, intermediate_size, num_heads, num_kv_heads, head_dim }
     }
 
     /// Number of Q heads on this GPU.
@@ -153,12 +145,7 @@ impl ColumnParallelShard {
         let col_start = tp_rank * local_output_dim;
         let col_end = col_start + local_output_dim;
 
-        Self {
-            input_dim,
-            local_output_dim,
-            col_start,
-            col_end,
-        }
+        Self { input_dim, local_output_dim, col_start, col_end }
     }
 
     /// Number of elements in the local weight shard.
@@ -205,12 +192,7 @@ impl RowParallelShard {
         let row_start = tp_rank * local_input_dim;
         let row_end = row_start + local_input_dim;
 
-        Self {
-            local_input_dim,
-            output_dim,
-            row_start,
-            row_end,
-        }
+        Self { local_input_dim, output_dim, row_start, row_end }
     }
 
     /// Number of elements in the local weight shard.

--- a/src/train/transformer_trainer/tests.rs
+++ b/src/train/transformer_trainer/tests.rs
@@ -328,12 +328,8 @@ fn falsify_alb038_training_changes_weights() {
     let mut trainer = TransformerTrainer::new(config);
 
     // Snapshot initial weights
-    let init_params: Vec<Vec<f32>> = trainer
-        .model()
-        .parameters()
-        .iter()
-        .map(|p| p.data().to_vec())
-        .collect();
+    let init_params: Vec<Vec<f32>> =
+        trainer.model().parameters().iter().map(|p| p.data().to_vec()).collect();
 
     // Train for several steps
     let batch = LMBatch::single(vec![1, 2, 3, 4], vec![2, 3, 4, 5]);
@@ -342,18 +338,17 @@ fn falsify_alb038_training_changes_weights() {
     }
 
     // Check that at least some weights changed
-    let final_params: Vec<Vec<f32>> = trainer
-        .model()
-        .parameters()
-        .iter()
-        .map(|p| p.data().to_vec())
-        .collect();
+    let final_params: Vec<Vec<f32>> =
+        trainer.model().parameters().iter().map(|p| p.data().to_vec()).collect();
 
     let mut changed_count = 0;
     for (i, (init, final_p)) in init_params.iter().zip(final_params.iter()).enumerate() {
         if init == final_p {
             // Log which parameter didn't change (for debugging)
-            eprintln!("ALB-038 WARNING: parameter {i} unchanged after training (len={})", init.len());
+            eprintln!(
+                "ALB-038 WARNING: parameter {i} unchanged after training (len={})",
+                init.len()
+            );
         } else {
             changed_count += 1;
         }
@@ -398,9 +393,7 @@ fn falsify_alb038_saved_weights_differ_from_init() {
 
     // Save to temp file
     let temp = NamedTempFile::new().expect("temp file creation should succeed");
-    trainer
-        .save(temp.path(), "alb038-test", "test")
-        .expect("save should succeed");
+    trainer.save(temp.path(), "alb038-test", "test").expect("save should succeed");
 
     // Load back and verify weights differ from init
     let data = std::fs::read(temp.path()).expect("file read should succeed");
@@ -411,7 +404,8 @@ fn falsify_alb038_saved_weights_differ_from_init() {
 
     // Saved embed weights must differ from init
     assert_ne!(
-        saved_data, &init_embed[..],
+        saved_data,
+        &init_embed[..],
         "FALSIFIED ALB-038: Saved embedding weights are identical to initialization"
     );
 }
@@ -462,12 +456,13 @@ fn test_deterministic_env_vars_set() {
 #[test]
 fn test_deterministic_disabled_no_env_change() {
     // When deterministic=false, apply_deterministic_settings() is a no-op
-    let config = TransformerTrainConfig::new(TransformerConfig::tiny())
-        .with_deterministic(false);
+    let config = TransformerTrainConfig::new(TransformerConfig::tiny()).with_deterministic(false);
     // Clear env first to verify it's not set
     // SAFETY: test runs single-threaded; remove_var needed to verify no-op behavior
     #[allow(clippy::disallowed_methods, unsafe_code)]
-    unsafe { std::env::remove_var("PYTHONHASHSEED") };
+    unsafe {
+        std::env::remove_var("PYTHONHASHSEED")
+    };
     config.apply_deterministic_settings();
     // PYTHONHASHSEED should NOT have been set
     assert!(
@@ -514,8 +509,7 @@ fn test_deterministic_training_reproducibility() {
 fn test_checkpoint_config_segment_calculation() {
     // Verify checkpoint boundary mask calculation
     // tiny has 2 layers, 2 segments → segment_size = 1 → all layers are checkpoints
-    let config = TransformerTrainConfig::new(TransformerConfig::tiny())
-        .with_checkpointing(2);
+    let config = TransformerTrainConfig::new(TransformerConfig::tiny()).with_checkpointing(2);
 
     assert!(config.checkpoint_config.enabled);
     assert_eq!(config.checkpoint_config.num_segments, 2);
@@ -525,9 +519,7 @@ fn test_checkpoint_config_segment_calculation() {
     let ns = config.checkpoint_config.num_segments.max(1);
     let segment_size = num_layers.div_ceil(ns);
     assert_eq!(segment_size, 1);
-    let mask: Vec<bool> = (0..num_layers)
-        .map(|i| i % segment_size == 0)
-        .collect();
+    let mask: Vec<bool> = (0..num_layers).map(|i| i % segment_size == 0).collect();
     assert_eq!(mask, vec![true, true]);
 }
 
@@ -537,17 +529,14 @@ fn test_checkpoint_config_fewer_segments() {
     // Checkpoint boundary layers: 0, 6, 12, 18
     let mut model_config = TransformerConfig::tiny();
     model_config.num_hidden_layers = 24;
-    let config = TransformerTrainConfig::new(model_config)
-        .with_checkpointing(4);
+    let config = TransformerTrainConfig::new(model_config).with_checkpointing(4);
 
     let num_layers = config.model_config.num_hidden_layers;
     assert_eq!(num_layers, 24);
     let ns = config.checkpoint_config.num_segments.max(1);
     let segment_size = num_layers.div_ceil(ns);
     assert_eq!(segment_size, 6);
-    let mask: Vec<bool> = (0..num_layers)
-        .map(|i| i % segment_size == 0)
-        .collect();
+    let mask: Vec<bool> = (0..num_layers).map(|i| i % segment_size == 0).collect();
     // Only layers 0, 6, 12, 18 are checkpoints
     let expected: Vec<bool> = (0..24).map(|i| i % 6 == 0).collect();
     assert_eq!(mask, expected);
@@ -600,15 +589,14 @@ fn test_gradient_accumulation_produces_different_weights_than_no_accum() {
     let batch = LMBatch::from_sequences(&[seq.clone()], 0, 0);
 
     // Train with accum=1 (immediate optimizer step)
-    let config_no_accum = TransformerTrainConfig::new(model_config.clone())
-        .with_lr(0.01)
-        .with_max_seq_len(32);
+    let config_no_accum =
+        TransformerTrainConfig::new(model_config.clone()).with_lr(0.01).with_max_seq_len(32);
     let model1 = Transformer::new(&model_config);
     let mut trainer1 = TransformerTrainer::with_model(model1, config_no_accum);
     trainer1.train_batch(&batch);
     trainer1.train_batch(&batch);
-    let weights1: Vec<f32> = trainer1.model().embed_tokens.weight.data()
-        .as_slice().unwrap().to_vec();
+    let weights1: Vec<f32> =
+        trainer1.model().embed_tokens.weight.data().as_slice().unwrap().to_vec();
 
     // Train with accum=2 (deferred optimizer step)
     let config_accum = TransformerTrainConfig::new(model_config.clone())
@@ -619,11 +607,12 @@ fn test_gradient_accumulation_produces_different_weights_than_no_accum() {
     let mut trainer2 = TransformerTrainer::with_model(model2, config_accum);
     trainer2.train_batch(&batch);
     trainer2.train_batch(&batch);
-    let weights2: Vec<f32> = trainer2.model().embed_tokens.weight.data()
-        .as_slice().unwrap().to_vec();
+    let weights2: Vec<f32> =
+        trainer2.model().embed_tokens.weight.data().as_slice().unwrap().to_vec();
 
     // Weights should differ (different optimizer dynamics)
-    let diff: f64 = weights1.iter().zip(&weights2).map(|(a, b)| (f64::from(*a) - f64::from(*b)).abs()).sum();
+    let diff: f64 =
+        weights1.iter().zip(&weights2).map(|(a, b)| (f64::from(*a) - f64::from(*b)).abs()).sum();
     assert!(diff > 1e-6, "Gradient accumulation should produce different weights (diff={diff})");
 }
 
@@ -638,8 +627,10 @@ fn test_per_block_gradient_accumulator_sizes() {
     let i = model_config.intermediate_size;
     let sizes = PerBlockGradientAccumulator::compute_block_sizes(h, kv, i);
     let accum = PerBlockGradientAccumulator::new(
-        model_config.num_hidden_layers, sizes,
-        model_config.vocab_size, h,
+        model_config.num_hidden_layers,
+        sizes,
+        model_config.vocab_size,
+        h,
     );
     assert_eq!(accum.num_blocks(), model_config.num_hidden_layers);
     assert_eq!(accum.lm_head_grad.len(), model_config.vocab_size * h);

--- a/src/train/transformer_trainer/trainer.rs
+++ b/src/train/transformer_trainer/trainer.rs
@@ -213,9 +213,7 @@ impl TransformerTrainer {
 
     /// Returns true if max_steps has been reached.
     pub fn reached_max_steps(&self) -> bool {
-        self.config
-            .max_steps
-            .is_some_and(|max| self.step >= max)
+        self.config.max_steps.is_some_and(|max| self.step >= max)
     }
 
     /// Get current step count

--- a/src/train/transformer_trainer/zero.rs
+++ b/src/train/transformer_trainer/zero.rs
@@ -58,19 +58,10 @@ impl OptimizerShard {
             remainder * (shard_size + 1) + (rank - remainder) * shard_size
         };
 
-        let param_end = if rank < remainder {
-            param_start + shard_size + 1
-        } else {
-            param_start + shard_size
-        };
+        let param_end =
+            if rank < remainder { param_start + shard_size + 1 } else { param_start + shard_size };
 
-        Self {
-            rank,
-            world_size,
-            param_start,
-            param_end,
-            total_params,
-        }
+        Self { rank, world_size, param_start, param_end, total_params }
     }
 
     /// Number of parameters in this shard.
@@ -130,17 +121,9 @@ impl ZeroShardMap {
     /// Non-block components (LM head, final norm, embedding) are assigned
     /// to rank 0 by default since they're relatively small.
     pub fn round_robin(num_blocks: usize, world_size: usize) -> Self {
-        let block_owners: Vec<usize> = (0..num_blocks)
-            .map(|i| i % world_size)
-            .collect();
+        let block_owners: Vec<usize> = (0..num_blocks).map(|i| i % world_size).collect();
 
-        Self {
-            block_owners,
-            lm_head_owner: 0,
-            final_norm_owner: 0,
-            embedding_owner: 0,
-            world_size,
-        }
+        Self { block_owners, lm_head_owner: 0, final_norm_owner: 0, embedding_owner: 0, world_size }
     }
 
     /// Create a shard map distributing blocks in contiguous chunks.
@@ -159,13 +142,7 @@ impl ZeroShardMap {
             }
         }
 
-        Self {
-            block_owners,
-            lm_head_owner: 0,
-            final_norm_owner: 0,
-            embedding_owner: 0,
-            world_size,
-        }
+        Self { block_owners, lm_head_owner: 0, final_norm_owner: 0, embedding_owner: 0, world_size }
     }
 
     /// Get the owning rank for a given block index.

--- a/src/train/tui/charts/loss_curve.rs
+++ b/src/train/tui/charts/loss_curve.rs
@@ -50,11 +50,11 @@ impl LossCurveDisplay {
             width,
             height,
         )
-            .margin(2)
-            .best_markers(true)
-            .lower_is_better(true)
-            .build()
-            .expect("LossCurve build should succeed");
+        .margin(2)
+        .best_markers(true)
+        .lower_is_better(true)
+        .build()
+        .expect("LossCurve build should succeed");
         Self { loss_curve, width, height, terminal_mode: TerminalMode::Unicode }
     }
 
@@ -74,11 +74,11 @@ impl LossCurveDisplay {
             self.width,
             self.height,
         )
-            .margin(2)
-            .best_markers(true)
-            .lower_is_better(true)
-            .build()
-            .expect("LossCurve build should succeed");
+        .margin(2)
+        .best_markers(true)
+        .lower_is_better(true)
+        .build()
+        .expect("LossCurve build should succeed");
         self
     }
 

--- a/src/transformer/attention.rs
+++ b/src/transformer/attention.rs
@@ -46,12 +46,20 @@ impl BackwardOp for AttentionBlockBackward {
         // Step 2-4: Scatter per-head grads into full Q/K/V
         scatter_head_grads_q(&self.q, &self.head_q_tensors, self.seq_len, h, self.q_dim);
         scatter_head_grads_kv(
-            &self.k, &self.head_k_tensors, &self.head_kv_indices,
-            self.seq_len, h, self.kv_hidden_size,
+            &self.k,
+            &self.head_k_tensors,
+            &self.head_kv_indices,
+            self.seq_len,
+            h,
+            self.kv_hidden_size,
         );
         scatter_head_grads_kv(
-            &self.v, &self.head_v_tensors, &self.head_kv_indices,
-            self.seq_len, h, self.kv_hidden_size,
+            &self.v,
+            &self.head_v_tensors,
+            &self.head_kv_indices,
+            self.seq_len,
+            h,
+            self.kv_hidden_size,
         );
 
         // Step 5: Propagate backward through Q/K/V matmuls (once each)
@@ -65,14 +73,19 @@ impl BackwardOp for AttentionBlockBackward {
 
 /// Split concat gradient per head and trigger each head's attention backward
 fn split_and_backward_heads(
-    go: &[f32], head_outputs: &[Tensor], seq_len: usize, head_dim: usize, q_dim: usize,
+    go: &[f32],
+    head_outputs: &[Tensor],
+    seq_len: usize,
+    head_dim: usize,
+    q_dim: usize,
 ) {
     for (head_idx, head_out) in head_outputs.iter().enumerate() {
         let mut grad_head = vec![0.0_f32; seq_len * head_dim];
         for s in 0..seq_len {
             let src_base = s * q_dim + head_idx * head_dim;
             let dst_base = s * head_dim;
-            grad_head[dst_base..dst_base + head_dim].copy_from_slice(&go[src_base..src_base + head_dim]);
+            grad_head[dst_base..dst_base + head_dim]
+                .copy_from_slice(&go[src_base..src_base + head_dim]);
         }
         head_out.accumulate_grad(Array1::from(grad_head));
         if let Some(op) = head_out.backward_op() {
@@ -83,9 +96,15 @@ fn split_and_backward_heads(
 
 /// Scatter per-head Q gradients into the full Q projection tensor
 fn scatter_head_grads_q(
-    q: &Tensor, head_q_tensors: &[Tensor], seq_len: usize, head_dim: usize, q_dim: usize,
+    q: &Tensor,
+    head_q_tensors: &[Tensor],
+    seq_len: usize,
+    head_dim: usize,
+    q_dim: usize,
 ) {
-    if !q.requires_grad() { return; }
+    if !q.requires_grad() {
+        return;
+    }
     let mut grad_q = vec![0.0_f32; seq_len * q_dim];
     for (head_idx, head_q) in head_q_tensors.iter().enumerate() {
         if let Some(hgrad) = head_q.grad() {
@@ -104,10 +123,16 @@ fn scatter_head_grads_q(
 
 /// Scatter per-head K or V gradients into the full K/V projection tensor (GQA-correct)
 fn scatter_head_grads_kv(
-    target: &Tensor, head_tensors: &[Tensor], kv_indices: &[usize],
-    seq_len: usize, head_dim: usize, kv_hidden_size: usize,
+    target: &Tensor,
+    head_tensors: &[Tensor],
+    kv_indices: &[usize],
+    seq_len: usize,
+    head_dim: usize,
+    kv_hidden_size: usize,
 ) {
-    if !target.requires_grad() { return; }
+    if !target.requires_grad() {
+        return;
+    }
     let mut grad = vec![0.0_f32; seq_len * kv_hidden_size];
     for (head_idx, head_t) in head_tensors.iter().enumerate() {
         let kv_h = kv_indices[head_idx];
@@ -153,9 +178,7 @@ impl MultiHeadAttention {
         Self {
             config: config.clone(),
             w_q: Tensor::from_vec(
-                (0..q_dim * hidden_size)
-                    .map(|i| ((i as f32 * 0.123).sin() * q_scale))
-                    .collect(),
+                (0..q_dim * hidden_size).map(|i| ((i as f32 * 0.123).sin() * q_scale)).collect(),
                 true,
             ),
             w_k: Tensor::from_vec(
@@ -171,9 +194,7 @@ impl MultiHeadAttention {
                 true,
             ),
             w_o: Tensor::from_vec(
-                (0..hidden_size * q_dim)
-                    .map(|i| ((i as f32 * 0.456).sin() * q_scale))
-                    .collect(),
+                (0..hidden_size * q_dim).map(|i| ((i as f32 * 0.456).sin() * q_scale)).collect(),
                 true,
             ),
         }
@@ -392,7 +413,8 @@ impl MultiHeadAttention {
         // V projection with LoRA (same pattern as Q)
         let v_base = matmul(x, &self.w_v, seq_len, hidden_size, kv_hidden_size);
         let v_mid = crate::autograd::matmul_nt(x, lora_a_v, seq_len, hidden_size, lora_rank);
-        let v_lora = crate::autograd::matmul_nt(&v_mid, lora_b_v, seq_len, lora_rank, kv_hidden_size);
+        let v_lora =
+            crate::autograd::matmul_nt(&v_mid, lora_b_v, seq_len, lora_rank, kv_hidden_size);
         let v = crate::autograd::add_scaled(&v_base, &v_lora, lora_scale);
 
         let requires_grad = q.requires_grad() || k.requires_grad() || v.requires_grad();
@@ -883,9 +905,8 @@ mod tests {
 
         // Non-uniform input: different positions must have different representations
         // so softmax produces non-uniform weights with non-zero score gradients
-        let x_data: Vec<f32> = (0..seq_len * hidden_size)
-            .map(|i| ((i as f32) * 0.17).sin() * 0.5)
-            .collect();
+        let x_data: Vec<f32> =
+            (0..seq_len * hidden_size).map(|i| ((i as f32) * 0.17).sin() * 0.5).collect();
         let x = Tensor::from_vec(x_data, true);
         let mut output = attn.forward(&x, seq_len);
 
@@ -893,16 +914,15 @@ mod tests {
         crate::autograd::backward(&mut output, Some(grad_out));
 
         // All four projection weights must receive gradients
-        for (name, param) in [("w_q", &attn.w_q), ("w_k", &attn.w_k), ("w_v", &attn.w_v), ("w_o", &attn.w_o)] {
+        for (name, param) in
+            [("w_q", &attn.w_q), ("w_k", &attn.w_k), ("w_v", &attn.w_v), ("w_o", &attn.w_o)]
+        {
             assert!(
                 param.grad().is_some(),
                 "ALB-038: {name} must have gradient after full attention forward"
             );
             let grad = param.grad().expect("gradient available");
-            assert!(
-                grad.iter().all(|&v| v.is_finite()),
-                "ALB-038: {name} gradient must be finite"
-            );
+            assert!(grad.iter().all(|&v| v.is_finite()), "ALB-038: {name} gradient must be finite");
             assert!(
                 grad.iter().any(|&v| v.abs() > 1e-10),
                 "ALB-038: {name} gradient must be non-zero"

--- a/src/transformer/config.rs
+++ b/src/transformer/config.rs
@@ -251,9 +251,9 @@ impl TransformerConfig {
             "7B" | "qwen2.5-7b" => Ok(Self::qwen2_7b()),
             "4B" | "qwen3-4b" | "qwen3" => Ok(Self::qwen3_4b()),
             "9B" | "qwen3.5-9b" | "qwen3_5" | "qwen3.5" => Ok(Self::qwen3_5_9b()),
-            unknown => Err(format!(
-                "Unknown model size '{unknown}'. Known sizes: 0.5B, 4B, 7B, 9B"
-            )),
+            unknown => {
+                Err(format!("Unknown model size '{unknown}'. Known sizes: 0.5B, 4B, 7B, 9B"))
+            }
         }
     }
 
@@ -279,8 +279,7 @@ impl TransformerConfig {
     /// Uses explicit override when set (Qwen3: head_dim=128 with hidden=2560, 32 heads).
     /// Falls back to hidden_size / num_heads for standard architectures.
     pub fn head_dim(&self) -> usize {
-        self.head_dim_override
-            .unwrap_or(self.hidden_size / self.num_attention_heads)
+        self.head_dim_override.unwrap_or(self.hidden_size / self.num_attention_heads)
     }
 
     /// Total Q/O projection dimension = num_heads * head_dim.
@@ -378,11 +377,8 @@ impl TransformerConfig {
         let linear_per_layer = self.per_layer_scratch_linear_coeff() * s;
 
         let (n_quad, n_hd_linear) = self.per_layer_scratch_quadratic_coeff();
-        let quadratic_per_layer = if s >= hd {
-            2 * n_quad * s * s
-        } else {
-            n_quad * s * s + n_hd_linear * s
-        };
+        let quadratic_per_layer =
+            if s >= hd { 2 * n_quad * s * s } else { n_quad * s * s + n_hd_linear * s };
 
         let elements_per_layer = constant_per_layer + linear_per_layer + quadratic_per_layer;
         l * elements_per_layer * 4 // f32 = 4 bytes
@@ -408,14 +404,10 @@ impl TransformerConfig {
         // Seq-len-dependent scratch: SHARED (one set)
         let linear_shared = self.per_layer_scratch_linear_coeff() * s;
         let (n_quad, n_hd_linear) = self.per_layer_scratch_quadratic_coeff();
-        let quadratic_shared = if s >= hd {
-            2 * n_quad * s * s
-        } else {
-            n_quad * s * s + n_hd_linear * s
-        };
+        let quadratic_shared =
+            if s >= hd { 2 * n_quad * s * s } else { n_quad * s * s + n_hd_linear * s };
 
-        let total_elements =
-            weights_total + grad_weights_shared + linear_shared + quadratic_shared;
+        let total_elements = weights_total + grad_weights_shared + linear_shared + quadratic_shared;
         total_elements * 4 // f32 = 4 bytes
     }
 
@@ -633,15 +625,33 @@ mod tests {
     fn test_from_apr_metadata_missing_required_returns_none() {
         // Missing hidden_size — must return None, not silently degrade
         assert!(TransformerConfig::from_apr_metadata(
-            None, Some(32), Some(8), Some(12288), Some(36), Some(151936),
-            Some(40960), Some(1e-6), Some(1e6), Some("qwen3"),
-        ).is_none());
+            None,
+            Some(32),
+            Some(8),
+            Some(12288),
+            Some(36),
+            Some(151936),
+            Some(40960),
+            Some(1e-6),
+            Some(1e6),
+            Some("qwen3"),
+        )
+        .is_none());
 
         // Missing num_layers
         assert!(TransformerConfig::from_apr_metadata(
-            Some(4096), Some(32), Some(8), Some(12288), None, Some(151936),
-            Some(40960), Some(1e-6), Some(1e6), Some("qwen3"),
-        ).is_none());
+            Some(4096),
+            Some(32),
+            Some(8),
+            Some(12288),
+            None,
+            Some(151936),
+            Some(40960),
+            Some(1e-6),
+            Some(1e6),
+            Some("qwen3"),
+        )
+        .is_none());
     }
 
     // =========================================================================
@@ -714,8 +724,14 @@ mod tests {
         let shared_512 = config.total_training_vram_bytes_shared(512);
         let solved = config.max_seq_len_for_vram_shared(24 * 1024 * 1024 * 1024);
         eprintln!("=== Qwen3-4B VRAM Budget ===");
-        eprintln!("  Per-layer weights:    {:.1} MB", config.per_layer_weight_elements() as f64 * 4.0 / 1e6);
-        eprintln!("  Per-layer grad scratch: {:.1} MB", config.per_layer_grad_weight_elements() as f64 * 4.0 / 1e6);
+        eprintln!(
+            "  Per-layer weights:    {:.1} MB",
+            config.per_layer_weight_elements() as f64 * 4.0 / 1e6
+        );
+        eprintln!(
+            "  Per-layer grad scratch: {:.1} MB",
+            config.per_layer_grad_weight_elements() as f64 * 4.0 / 1e6
+        );
         eprintln!("  Per-layer (S=512): {:.1} MB", (vram_512 / 36) as f64 / 1e6);
         eprintln!("  36 layers S=1 (per-layer scratch): {:.1} GB", vram_1 as f64 / 1e9);
         eprintln!("  36 layers S=512 (per-layer scratch): {:.1} GB", vram_512 as f64 / 1e9);
@@ -752,8 +768,8 @@ mod tests {
         // Per-layer weights: q(4096*2560) + k(1024*2560) + v(1024*2560)
         //   + o(2560*4096) + gate(9728*2560) + up(9728*2560) + down(2560*9728)
         //   + norms(2560*2)
-        let expected_weights = 4096 * 2560 + 1024 * 2560 * 2 + 2560 * 4096
-            + 9728 * 2560 * 3 + 2560 * 2;
+        let expected_weights =
+            4096 * 2560 + 1024 * 2560 * 2 + 2560 * 4096 + 9728 * 2560 * 3 + 2560 * 2;
         assert_eq!(config.per_layer_weight_elements(), expected_weights);
 
         // With PER-LAYER gradient scratch (current cuda_block.rs layout),

--- a/src/transformer/cuda_block.rs
+++ b/src/transformer/cuda_block.rs
@@ -43,14 +43,14 @@ use crate::autograd::cuda_backward::{
     batched_softmax_backward, gemm_backward_a, gemm_backward_b, rms_norm_backward, silu_backward,
 };
 #[cfg(feature = "cuda")]
-use crate::autograd::cuda_optim::adamw_step_cuda;
-#[cfg(feature = "cuda")]
 use crate::autograd::cuda_forward::{
     batched_4d_gemm_forward, batched_softmax_forward, batched_to_interleaved_forward,
     batched_transpose_forward, elementwise_mul_forward, expand_kv_heads, fused_swiglu_forward,
     gemm_forward, interleaved_to_batched_forward, residual_add_forward, rms_norm_forward,
     scale_forward, silu_forward,
 };
+#[cfg(feature = "cuda")]
+use crate::autograd::cuda_optim::adamw_step_cuda;
 #[cfg(feature = "cuda")]
 use crate::autograd::cuda_tensor::Result;
 
@@ -159,7 +159,12 @@ impl CudaBlockScratch {
     /// # Contract (C-SCRATCH-001)
     ///
     /// All buffer sizes are deterministic from (config, max_seq_len).
-    pub(crate) fn new(config: &TransformerConfig, max_seq_len: usize, ctx: &Arc<CudaContext>, lora_rank: usize) -> Result<Self> {
+    pub(crate) fn new(
+        config: &TransformerConfig,
+        max_seq_len: usize,
+        ctx: &Arc<CudaContext>,
+        lora_rank: usize,
+    ) -> Result<Self> {
         let hidden_size = config.hidden_size;
         let q_dim = config.q_dim();
         let kv_hidden_size = config.num_kv_heads * config.head_dim();
@@ -887,12 +892,7 @@ impl CudaTransformerBlock {
         // up_out now holds grad_gate [S,I]
 
         // Step 5: silu_gate = silu(gate_out) → swiglu_out [S,I]
-        silu_forward(
-            &self.scratch.gate_out,
-            &mut self.scratch.swiglu_out,
-            n_inter,
-            stream,
-        )?;
+        silu_forward(&self.scratch.gate_out, &mut self.scratch.swiglu_out, n_inter, stream)?;
 
         // Step 6: grad_up = grad_swiglu * silu_gate → gate_out [S,I]
         elementwise_mul_forward(
@@ -1149,8 +1149,8 @@ impl CudaTransformerBlock {
         // Step B: GEMM [H,hd,S] @ [H,S,S] → [H,hd,S] (= grad_V^T)
         batched_4d_gemm_forward(
             &self.scratch.attn_kv_temp,      // grad_attn_batched^T [H, hd, S]
-            &self.scratch.attn_scores,        // attn_weights [H, S, S]
-            &mut self.scratch.attn_kv_temp2,  // grad_V^T [H, hd, S]
+            &self.scratch.attn_scores,       // attn_weights [H, S, S]
+            &mut self.scratch.attn_kv_temp2, // grad_V^T [H, hd, S]
             1,
             nh,
             hd,  // m
@@ -1372,7 +1372,12 @@ impl CudaTransformerBlock {
             saturating_u32(kv_hidden_size),
             stream,
         )?;
-        cuda_add_inplace(&mut self.scratch.grad_hidden, &self.scratch.grad_attn_scores, seq_len * hidden_size, stream)?;
+        cuda_add_inplace(
+            &mut self.scratch.grad_hidden,
+            &self.scratch.grad_attn_scores,
+            seq_len * hidden_size,
+            stream,
+        )?;
 
         // grad_norm1 += grad_v @ w_v^T
         gemm_backward_a(
@@ -1384,7 +1389,12 @@ impl CudaTransformerBlock {
             saturating_u32(kv_hidden_size),
             stream,
         )?;
-        cuda_add_inplace(&mut self.scratch.grad_hidden, &self.scratch.grad_attn_scores, seq_len * hidden_size, stream)?;
+        cuda_add_inplace(
+            &mut self.scratch.grad_hidden,
+            &self.scratch.grad_attn_scores,
+            seq_len * hidden_size,
+            stream,
+        )?;
 
         // Weight gradients: grad_w_q = norm1_out^T @ grad_q
         gemm_backward_b(
@@ -1422,13 +1432,11 @@ impl CudaTransformerBlock {
         // Copy grad_hidden → grad_input for downstream (residual backward)
         // SAFETY: Both buffers are valid GPU allocations with matching sizes.
         unsafe {
-            grad_input
-                .copy_from_buffer_async(&self.scratch.grad_hidden, stream)
-                .map_err(|e| {
-                    crate::autograd::cuda_tensor::CudaTensorError::TransferFailed(format!(
-                        "Attn backward grad_hidden → grad_input D2D copy failed: {e}"
-                    ))
-                })?;
+            grad_input.copy_from_buffer_async(&self.scratch.grad_hidden, stream).map_err(|e| {
+                crate::autograd::cuda_tensor::CudaTensorError::TransferFailed(format!(
+                    "Attn backward grad_hidden → grad_input D2D copy failed: {e}"
+                ))
+            })?;
         }
 
         Ok(())
@@ -1452,14 +1460,10 @@ impl CudaTransformerBlock {
         let elems_per_head = seq_len * head_dim;
 
         // Reduce grad_K: attn_kv_temp2 [H] → grad_attn_scores [nkv]
-        self.reduce_single_gqa_gradient(
-            true, num_kv_heads, heads_per_kv, elems_per_head, stream,
-        )?;
+        self.reduce_single_gqa_gradient(true, num_kv_heads, heads_per_kv, elems_per_head, stream)?;
 
         // Reduce grad_V: attn_kv_temp [H] → ffn_out [nkv]
-        self.reduce_single_gqa_gradient(
-            false, num_kv_heads, heads_per_kv, elems_per_head, stream,
-        )?;
+        self.reduce_single_gqa_gradient(false, num_kv_heads, heads_per_kv, elems_per_head, stream)?;
 
         // Copy reduced results to known locations for step 4.8
         let kv_elems = num_kv_heads * elems_per_head;
@@ -1529,11 +1533,8 @@ impl CudaTransformerBlock {
                 // Head extraction into o_proj_out buffer
                 // SAFETY: Valid GPU allocations with sufficient size.
                 unsafe {
-                    let src = if is_k {
-                        &self.scratch.attn_kv_temp2
-                    } else {
-                        &self.scratch.attn_kv_temp
-                    };
+                    let src =
+                        if is_k { &self.scratch.attn_kv_temp2 } else { &self.scratch.attn_kv_temp };
                     self.scratch
                         .o_proj_out
                         .copy_from_buffer_at_async(src, 0, h_offset, elems_per_head, stream)
@@ -1547,11 +1548,8 @@ impl CudaTransformerBlock {
                 // Add: dst[dst_offset..] += o_proj_out[0..elems_per_head]
                 // SAFETY: Creating non-owning views for arithmetic; forgotten to prevent double-free.
                 unsafe {
-                    let dst_buf = if is_k {
-                        &self.scratch.grad_attn_scores
-                    } else {
-                        &self.scratch.ffn_out
-                    };
+                    let dst_buf =
+                        if is_k { &self.scratch.grad_attn_scores } else { &self.scratch.ffn_out };
                     let dst_view = GpuBuffer::<f32>::from_raw_parts(
                         dst_buf.as_ptr() + (dst_offset as u64 * 4),
                         elems_per_head,
@@ -1579,7 +1577,11 @@ impl CudaTransformerBlock {
                     };
                     dst_buf
                         .copy_from_buffer_at_async(
-                            &self.scratch.grad_hidden, dst_offset, 0, elems_per_head, stream,
+                            &self.scratch.grad_hidden,
+                            dst_offset,
+                            0,
+                            elems_per_head,
+                            stream,
                         )
                         .map_err(|e| {
                             crate::autograd::cuda_tensor::CudaTensorError::TransferFailed(format!(
@@ -1614,14 +1616,11 @@ impl CudaTransformerBlock {
         // D2D copy grad_input to grad_hidden (rms_norm_backward needs separate input/output)
         // SAFETY: Both buffers are valid GPU allocations with matching sizes.
         unsafe {
-            self.scratch
-                .grad_hidden
-                .copy_from_buffer_async(grad_input, stream)
-                .map_err(|e| {
-                    crate::autograd::cuda_tensor::CudaTensorError::TransferFailed(format!(
-                        "Backward residual grad_hidden D2D copy failed: {e}"
-                    ))
-                })?;
+            self.scratch.grad_hidden.copy_from_buffer_async(grad_input, stream).map_err(|e| {
+                crate::autograd::cuda_tensor::CudaTensorError::TransferFailed(format!(
+                    "Backward residual grad_hidden D2D copy failed: {e}"
+                ))
+            })?;
         }
 
         rms_norm_backward(
@@ -1660,15 +1659,24 @@ impl CudaTransformerBlock {
             Ok(GpuBuffer::from_host(&self.ctx, &vec![0.0f32; n])?)
         };
         Ok(GpuBlockOptimizerState {
-            m_w_q: z(hidden * hidden)?,       v_w_q: z(hidden * hidden)?,
-            m_w_k: z(hidden * kv_hidden)?,    v_w_k: z(hidden * kv_hidden)?,
-            m_w_v: z(hidden * kv_hidden)?,    v_w_v: z(hidden * kv_hidden)?,
-            m_w_o: z(hidden * hidden)?,       v_w_o: z(hidden * hidden)?,
-            m_w_gate: z(hidden * intermediate)?, v_w_gate: z(hidden * intermediate)?,
-            m_w_up: z(hidden * intermediate)?,   v_w_up: z(hidden * intermediate)?,
-            m_w_down: z(intermediate * hidden)?, v_w_down: z(intermediate * hidden)?,
-            m_input_norm: z(hidden)?,         v_input_norm: z(hidden)?,
-            m_post_attn_norm: z(hidden)?,     v_post_attn_norm: z(hidden)?,
+            m_w_q: z(hidden * hidden)?,
+            v_w_q: z(hidden * hidden)?,
+            m_w_k: z(hidden * kv_hidden)?,
+            v_w_k: z(hidden * kv_hidden)?,
+            m_w_v: z(hidden * kv_hidden)?,
+            v_w_v: z(hidden * kv_hidden)?,
+            m_w_o: z(hidden * hidden)?,
+            v_w_o: z(hidden * hidden)?,
+            m_w_gate: z(hidden * intermediate)?,
+            v_w_gate: z(hidden * intermediate)?,
+            m_w_up: z(hidden * intermediate)?,
+            v_w_up: z(hidden * intermediate)?,
+            m_w_down: z(intermediate * hidden)?,
+            v_w_down: z(intermediate * hidden)?,
+            m_input_norm: z(hidden)?,
+            v_input_norm: z(hidden)?,
+            m_post_attn_norm: z(hidden)?,
+            v_post_attn_norm: z(hidden)?,
         })
     }
 
@@ -1712,53 +1720,134 @@ impl CudaTransformerBlock {
 
         // Attention projection weights
         adamw_step_cuda(
-            &mut self.w_q, &grad_ws.grad_w_q,
-            &mut state.m_w_q, &mut state.v_w_q,
-            lr, beta1, beta2, eps, weight_decay, step, n_wq, stream,
+            &mut self.w_q,
+            &grad_ws.grad_w_q,
+            &mut state.m_w_q,
+            &mut state.v_w_q,
+            lr,
+            beta1,
+            beta2,
+            eps,
+            weight_decay,
+            step,
+            n_wq,
+            stream,
         )?;
         adamw_step_cuda(
-            &mut self.w_k, &grad_ws.grad_w_k,
-            &mut state.m_w_k, &mut state.v_w_k,
-            lr, beta1, beta2, eps, weight_decay, step, n_wk, stream,
+            &mut self.w_k,
+            &grad_ws.grad_w_k,
+            &mut state.m_w_k,
+            &mut state.v_w_k,
+            lr,
+            beta1,
+            beta2,
+            eps,
+            weight_decay,
+            step,
+            n_wk,
+            stream,
         )?;
         adamw_step_cuda(
-            &mut self.w_v, &grad_ws.grad_w_v,
-            &mut state.m_w_v, &mut state.v_w_v,
-            lr, beta1, beta2, eps, weight_decay, step, n_wv, stream,
+            &mut self.w_v,
+            &grad_ws.grad_w_v,
+            &mut state.m_w_v,
+            &mut state.v_w_v,
+            lr,
+            beta1,
+            beta2,
+            eps,
+            weight_decay,
+            step,
+            n_wv,
+            stream,
         )?;
         adamw_step_cuda(
-            &mut self.w_o, &grad_ws.grad_w_o,
-            &mut state.m_w_o, &mut state.v_w_o,
-            lr, beta1, beta2, eps, weight_decay, step, n_wo, stream,
+            &mut self.w_o,
+            &grad_ws.grad_w_o,
+            &mut state.m_w_o,
+            &mut state.v_w_o,
+            lr,
+            beta1,
+            beta2,
+            eps,
+            weight_decay,
+            step,
+            n_wo,
+            stream,
         )?;
 
         // FFN projection weights
         adamw_step_cuda(
-            &mut self.w_gate, &grad_ws.grad_gate,
-            &mut state.m_w_gate, &mut state.v_w_gate,
-            lr, beta1, beta2, eps, weight_decay, step, n_gate, stream,
+            &mut self.w_gate,
+            &grad_ws.grad_gate,
+            &mut state.m_w_gate,
+            &mut state.v_w_gate,
+            lr,
+            beta1,
+            beta2,
+            eps,
+            weight_decay,
+            step,
+            n_gate,
+            stream,
         )?;
         adamw_step_cuda(
-            &mut self.w_up, &grad_ws.grad_up,
-            &mut state.m_w_up, &mut state.v_w_up,
-            lr, beta1, beta2, eps, weight_decay, step, n_up, stream,
+            &mut self.w_up,
+            &grad_ws.grad_up,
+            &mut state.m_w_up,
+            &mut state.v_w_up,
+            lr,
+            beta1,
+            beta2,
+            eps,
+            weight_decay,
+            step,
+            n_up,
+            stream,
         )?;
         adamw_step_cuda(
-            &mut self.w_down, &grad_ws.grad_down,
-            &mut state.m_w_down, &mut state.v_w_down,
-            lr, beta1, beta2, eps, weight_decay, step, n_down, stream,
+            &mut self.w_down,
+            &grad_ws.grad_down,
+            &mut state.m_w_down,
+            &mut state.v_w_down,
+            lr,
+            beta1,
+            beta2,
+            eps,
+            weight_decay,
+            step,
+            n_down,
+            stream,
         )?;
 
         // RMSNorm weights
         adamw_step_cuda(
-            &mut self.input_norm_weight, &grad_ws.grad_input_norm,
-            &mut state.m_input_norm, &mut state.v_input_norm,
-            lr, beta1, beta2, eps, weight_decay, step, n_inorm, stream,
+            &mut self.input_norm_weight,
+            &grad_ws.grad_input_norm,
+            &mut state.m_input_norm,
+            &mut state.v_input_norm,
+            lr,
+            beta1,
+            beta2,
+            eps,
+            weight_decay,
+            step,
+            n_inorm,
+            stream,
         )?;
         adamw_step_cuda(
-            &mut self.post_attn_norm_weight, &grad_ws.grad_post_attn_norm,
-            &mut state.m_post_attn_norm, &mut state.v_post_attn_norm,
-            lr, beta1, beta2, eps, weight_decay, step, n_panorm, stream,
+            &mut self.post_attn_norm_weight,
+            &grad_ws.grad_post_attn_norm,
+            &mut state.m_post_attn_norm,
+            &mut state.v_post_attn_norm,
+            lr,
+            beta1,
+            beta2,
+            eps,
+            weight_decay,
+            step,
+            n_panorm,
+            stream,
         )?;
 
         Ok(())
@@ -1862,13 +1951,7 @@ fn cuda_mul(
     n: usize,
     stream: &CudaStream,
 ) -> Result<()> {
-    crate::autograd::cuda_forward::elementwise_mul_forward(
-        a,
-        b,
-        output,
-        saturating_u32(n),
-        stream,
-    )
+    crate::autograd::cuda_forward::elementwise_mul_forward(a, b, output, saturating_u32(n), stream)
 }
 
 // CPU fallback stub
@@ -1915,7 +1998,8 @@ impl CudaBlock {
         match self {
             CudaBlock::Fp32(b) => b.forward(input, output, seq_len, stream),
             CudaBlock::Nf4(b) => {
-                let scratch = shared_scratch.expect("C-SCRATCH-001: NF4 blocks require shared scratch");
+                let scratch =
+                    shared_scratch.expect("C-SCRATCH-001: NF4 blocks require shared scratch");
                 b.forward(input, output, seq_len, stream, scratch)
             }
         }
@@ -1943,8 +2027,12 @@ impl CudaBlock {
         grad_ws: &mut CudaGradWorkspace,
     ) -> Result<()> {
         match self {
-            CudaBlock::Fp32(b) => b.backward(input, grad_output, grad_input, seq_len, stream, grad_ws),
-            CudaBlock::Nf4(_) => Err(crate::autograd::cuda_tensor::CudaTensorError::KernelError("backward not supported on NF4 blocks (frozen weights)".into())),
+            CudaBlock::Fp32(b) => {
+                b.backward(input, grad_output, grad_input, seq_len, stream, grad_ws)
+            }
+            CudaBlock::Nf4(_) => Err(crate::autograd::cuda_tensor::CudaTensorError::KernelError(
+                "backward not supported on NF4 blocks (frozen weights)".into(),
+            )),
         }
     }
 
@@ -1952,7 +2040,9 @@ impl CudaBlock {
     pub fn init_optimizer_state(&self) -> Result<GpuBlockOptimizerState> {
         match self {
             CudaBlock::Fp32(b) => b.init_optimizer_state(),
-            CudaBlock::Nf4(_) => Err(crate::autograd::cuda_tensor::CudaTensorError::KernelError("init_optimizer_state not supported on NF4 blocks".into())),
+            CudaBlock::Nf4(_) => Err(crate::autograd::cuda_tensor::CudaTensorError::KernelError(
+                "init_optimizer_state not supported on NF4 blocks".into(),
+            )),
         }
     }
 
@@ -1960,7 +2050,9 @@ impl CudaBlock {
     pub fn download_weights(&self) -> Result<BlockWeights> {
         match self {
             CudaBlock::Fp32(b) => b.download_weights(),
-            CudaBlock::Nf4(_) => Err(crate::autograd::cuda_tensor::CudaTensorError::KernelError("download_weights not supported on NF4 blocks".into())),
+            CudaBlock::Nf4(_) => Err(crate::autograd::cuda_tensor::CudaTensorError::KernelError(
+                "download_weights not supported on NF4 blocks".into(),
+            )),
         }
     }
 
@@ -1978,8 +2070,12 @@ impl CudaBlock {
         grad_ws: &CudaGradWorkspace,
     ) -> Result<()> {
         match self {
-            CudaBlock::Fp32(b) => b.optimizer_step(state, step, lr, beta1, beta2, eps, weight_decay, stream, grad_ws),
-            CudaBlock::Nf4(_) => Err(crate::autograd::cuda_tensor::CudaTensorError::KernelError("optimizer_step not supported on NF4 blocks (frozen weights)".into())),
+            CudaBlock::Fp32(b) => {
+                b.optimizer_step(state, step, lr, beta1, beta2, eps, weight_decay, stream, grad_ws)
+            }
+            CudaBlock::Nf4(_) => Err(crate::autograd::cuda_tensor::CudaTensorError::KernelError(
+                "optimizer_step not supported on NF4 blocks (frozen weights)".into(),
+            )),
         }
     }
 
@@ -2000,11 +2096,17 @@ impl CudaBlock {
     ) -> Result<()> {
         match self {
             CudaBlock::Nf4(b) => b.backward(
-                layer_input, grad_output, grad_input, output_scratch,
-                seq_len, stream, shared_scratch, grad_lora,
+                layer_input,
+                grad_output,
+                grad_input,
+                output_scratch,
+                seq_len,
+                stream,
+                shared_scratch,
+                grad_lora,
             ),
             CudaBlock::Fp32(_) => Err(crate::autograd::cuda_tensor::CudaTensorError::KernelError(
-                "backward_nf4 only supported on NF4 blocks".into()
+                "backward_nf4 only supported on NF4 blocks".into(),
             )),
         }
     }
@@ -2014,7 +2116,7 @@ impl CudaBlock {
         match self {
             CudaBlock::Nf4(b) => b.init_lora_optimizer_state(),
             CudaBlock::Fp32(_) => Err(crate::autograd::cuda_tensor::CudaTensorError::KernelError(
-                "init_lora_optimizer_state only supported on NF4 blocks".into()
+                "init_lora_optimizer_state only supported on NF4 blocks".into(),
             )),
         }
     }
@@ -2035,10 +2137,18 @@ impl CudaBlock {
     ) -> Result<()> {
         match self {
             CudaBlock::Nf4(b) => b.lora_optimizer_step(
-                state, step, lr, beta1, beta2, eps, weight_decay, stream, grad_lora,
+                state,
+                step,
+                lr,
+                beta1,
+                beta2,
+                eps,
+                weight_decay,
+                stream,
+                grad_lora,
             ),
             CudaBlock::Fp32(_) => Err(crate::autograd::cuda_tensor::CudaTensorError::KernelError(
-                "lora_optimizer_step only supported on NF4 blocks".into()
+                "lora_optimizer_step only supported on NF4 blocks".into(),
             )),
         }
     }
@@ -2048,7 +2158,7 @@ impl CudaBlock {
         match self {
             CudaBlock::Nf4(b) => b.download_lora_weights(),
             CudaBlock::Fp32(_) => Err(crate::autograd::cuda_tensor::CudaTensorError::KernelError(
-                "download_lora_weights only supported on NF4 blocks".into()
+                "download_lora_weights only supported on NF4 blocks".into(),
             )),
         }
     }
@@ -2104,10 +2214,10 @@ pub struct CudaNf4TransformerBlock {
     w_down_scales: GpuBuffer<f32>,
     // LoRA adapters for Q and V projections (ENT-153: QLoRA backward)
     // None when LoRA is not active (inference-only or non-QLoRA training)
-    lora_a_q: Option<GpuBuffer<f32>>,    // [hidden_size, rank]
-    lora_b_q: Option<GpuBuffer<f32>>,    // [rank, q_dim]
-    lora_a_v: Option<GpuBuffer<f32>>,    // [hidden_size, rank]
-    lora_b_v: Option<GpuBuffer<f32>>,    // [rank, kv_hidden]
+    lora_a_q: Option<GpuBuffer<f32>>, // [hidden_size, rank]
+    lora_b_q: Option<GpuBuffer<f32>>, // [rank, q_dim]
+    lora_a_v: Option<GpuBuffer<f32>>, // [hidden_size, rank]
+    lora_b_v: Option<GpuBuffer<f32>>, // [rank, kv_hidden]
     lora_scale: f32,
     lora_rank: usize,
     ctx: Arc<CudaContext>,
@@ -2152,21 +2262,55 @@ impl CudaNf4TransformerBlock {
         // Ground truth: PMAT-331 validation in attention.rs from_pretrained()
         //   Q: [q_dim, hidden], K: [kv_hidden, hidden], V: [kv_hidden, hidden], O: [hidden, q_dim]
         //   gate: [intermediate, hidden], up: [intermediate, hidden], down: [hidden, intermediate]
-        assert_eq!(w_q.len(), q_dim * hidden_size,
+        assert_eq!(
+            w_q.len(),
+            q_dim * hidden_size,
             "C-NF4SHAPE-001: w_q expected {}, got {} (q_dim={q_dim}, hidden={hidden_size})",
-            q_dim * hidden_size, w_q.len());
-        assert_eq!(w_k.len(), kv_hidden_size * hidden_size,
-            "C-NF4SHAPE-001: w_k expected {}, got {}", kv_hidden_size * hidden_size, w_k.len());
-        assert_eq!(w_v.len(), kv_hidden_size * hidden_size,
-            "C-NF4SHAPE-001: w_v expected {}, got {}", kv_hidden_size * hidden_size, w_v.len());
-        assert_eq!(w_o.len(), hidden_size * q_dim,
-            "C-NF4SHAPE-001: w_o expected {}, got {}", hidden_size * q_dim, w_o.len());
-        assert_eq!(w_gate.len(), intermediate_size * hidden_size,
-            "C-NF4SHAPE-001: w_gate expected {}, got {}", intermediate_size * hidden_size, w_gate.len());
-        assert_eq!(w_up.len(), intermediate_size * hidden_size,
-            "C-NF4SHAPE-001: w_up expected {}, got {}", intermediate_size * hidden_size, w_up.len());
-        assert_eq!(w_down.len(), hidden_size * intermediate_size,
-            "C-NF4SHAPE-001: w_down expected {}, got {}", hidden_size * intermediate_size, w_down.len());
+            q_dim * hidden_size,
+            w_q.len()
+        );
+        assert_eq!(
+            w_k.len(),
+            kv_hidden_size * hidden_size,
+            "C-NF4SHAPE-001: w_k expected {}, got {}",
+            kv_hidden_size * hidden_size,
+            w_k.len()
+        );
+        assert_eq!(
+            w_v.len(),
+            kv_hidden_size * hidden_size,
+            "C-NF4SHAPE-001: w_v expected {}, got {}",
+            kv_hidden_size * hidden_size,
+            w_v.len()
+        );
+        assert_eq!(
+            w_o.len(),
+            hidden_size * q_dim,
+            "C-NF4SHAPE-001: w_o expected {}, got {}",
+            hidden_size * q_dim,
+            w_o.len()
+        );
+        assert_eq!(
+            w_gate.len(),
+            intermediate_size * hidden_size,
+            "C-NF4SHAPE-001: w_gate expected {}, got {}",
+            intermediate_size * hidden_size,
+            w_gate.len()
+        );
+        assert_eq!(
+            w_up.len(),
+            intermediate_size * hidden_size,
+            "C-NF4SHAPE-001: w_up expected {}, got {}",
+            intermediate_size * hidden_size,
+            w_up.len()
+        );
+        assert_eq!(
+            w_down.len(),
+            hidden_size * intermediate_size,
+            "C-NF4SHAPE-001: w_down expected {}, got {}",
+            hidden_size * intermediate_size,
+            w_down.len()
+        );
 
         // Upload norm weights as fp32
         let input_norm_weight = GpuBuffer::from_host(&ctx, input_norm_weight)?;
@@ -2197,8 +2341,7 @@ impl CudaNf4TransformerBlock {
         let (w_o_nf4, w_o_scales) = quantize_and_upload(w_o, hidden_size * q_dim)?;
         let (w_gate_nf4, w_gate_scales) =
             quantize_and_upload(w_gate, intermediate_size * hidden_size)?;
-        let (w_up_nf4, w_up_scales) =
-            quantize_and_upload(w_up, intermediate_size * hidden_size)?;
+        let (w_up_nf4, w_up_scales) = quantize_and_upload(w_up, intermediate_size * hidden_size)?;
         let (w_down_nf4, w_down_scales) =
             quantize_and_upload(w_down, hidden_size * intermediate_size)?;
 
@@ -2428,13 +2571,7 @@ impl CudaNf4TransformerBlock {
         )?;
 
         // === Final Residual Add ===
-        cuda_add(
-            &scratch.residual1,
-            &scratch.ffn_out,
-            output,
-            seq_len * hidden_size,
-            stream,
-        )?;
+        cuda_add(&scratch.residual1, &scratch.ffn_out, output, seq_len * hidden_size, stream)?;
 
         Ok(())
     }
@@ -2451,7 +2588,12 @@ impl CudaNf4TransformerBlock {
 /// since attention operates on fp32 activations (Q/K/V are already dequantized by GEMM).
 #[cfg(feature = "cuda")]
 impl CudaNf4TransformerBlock {
-    fn compute_attention_cuda(&self, seq_len: usize, stream: &CudaStream, scratch: &mut CudaBlockScratch) -> Result<()> {
+    fn compute_attention_cuda(
+        &self,
+        seq_len: usize,
+        stream: &CudaStream,
+        scratch: &mut CudaBlockScratch,
+    ) -> Result<()> {
         let num_heads = self.config.num_attention_heads;
         let num_kv_heads = self.config.num_kv_heads;
         let head_dim = self.config.head_dim();
@@ -2463,38 +2605,30 @@ impl CudaNf4TransformerBlock {
         let hd = saturating_u32(head_dim);
 
         // Q: interleaved → batched layout
-        interleaved_to_batched_forward(
-            &scratch.q,
-            &mut scratch.attn_q_batched,
-            s, nh, hd,
-            stream,
-        )?;
+        interleaved_to_batched_forward(&scratch.q, &mut scratch.attn_q_batched, s, nh, hd, stream)?;
 
         // K: interleaved → batched, then GQA expand if needed
-        interleaved_to_batched_forward(
-            &scratch.k,
-            &mut scratch.attn_kv_temp,
-            s, nkv, hd,
-            stream,
-        )?;
+        interleaved_to_batched_forward(&scratch.k, &mut scratch.attn_kv_temp, s, nkv, hd, stream)?;
 
         if heads_per_kv > 1 {
             expand_kv_heads(
                 &scratch.attn_kv_temp,
                 &mut scratch.attn_kv_temp2,
-                num_kv_heads, heads_per_kv,
+                num_kv_heads,
+                heads_per_kv,
                 seq_len * head_dim,
                 stream,
             )?;
         } else {
             // SAFETY: D2D copy with matching buffer sizes
             unsafe {
-                scratch.attn_kv_temp2
+                scratch
+                    .attn_kv_temp2
                     .copy_from_buffer_async(&scratch.attn_kv_temp, stream)
                     .map_err(|e| {
-                        crate::autograd::cuda_tensor::CudaTensorError::TransferFailed(
-                            format!("K copy failed: {e:?}"),
-                        )
+                        crate::autograd::cuda_tensor::CudaTensorError::TransferFailed(format!(
+                            "K copy failed: {e:?}"
+                        ))
                     })?;
             }
         }
@@ -2503,7 +2637,9 @@ impl CudaNf4TransformerBlock {
         batched_transpose_forward(
             &scratch.attn_kv_temp2,
             &mut scratch.attn_kv_temp,
-            nh, s, hd,
+            nh,
+            s,
+            hd,
             stream,
         )?;
 
@@ -2512,7 +2648,11 @@ impl CudaNf4TransformerBlock {
             &scratch.attn_q_batched,
             &scratch.attn_kv_temp,
             &mut scratch.attn_scores,
-            1, nh, s, s, hd,
+            1,
+            nh,
+            s,
+            s,
+            hd,
             stream,
         )?;
 
@@ -2553,29 +2693,26 @@ impl CudaNf4TransformerBlock {
         leak(scores_view);
 
         // V: interleaved → batched, then GQA expand
-        interleaved_to_batched_forward(
-            &scratch.v,
-            &mut scratch.attn_kv_temp,
-            s, nkv, hd,
-            stream,
-        )?;
+        interleaved_to_batched_forward(&scratch.v, &mut scratch.attn_kv_temp, s, nkv, hd, stream)?;
 
         if heads_per_kv > 1 {
             expand_kv_heads(
                 &scratch.attn_kv_temp,
                 &mut scratch.attn_kv_temp2,
-                num_kv_heads, heads_per_kv,
+                num_kv_heads,
+                heads_per_kv,
                 seq_len * head_dim,
                 stream,
             )?;
         } else {
             unsafe {
-                scratch.attn_kv_temp2
+                scratch
+                    .attn_kv_temp2
                     .copy_from_buffer_async(&scratch.attn_kv_temp, stream)
                     .map_err(|e| {
-                        crate::autograd::cuda_tensor::CudaTensorError::TransferFailed(
-                            format!("V copy failed: {e:?}"),
-                        )
+                        crate::autograd::cuda_tensor::CudaTensorError::TransferFailed(format!(
+                            "V copy failed: {e:?}"
+                        ))
                     })?;
             }
         }
@@ -2585,7 +2722,11 @@ impl CudaNf4TransformerBlock {
             &scratch.attn_scores,
             &scratch.attn_kv_temp2,
             &mut scratch.attn_q_batched,
-            1, nh, s, hd, s,
+            1,
+            nh,
+            s,
+            hd,
+            s,
             stream,
         )?;
 
@@ -2593,7 +2734,9 @@ impl CudaNf4TransformerBlock {
         batched_to_interleaved_forward(
             &scratch.attn_q_batched,
             &mut scratch.attn_out,
-            s, nh, hd,
+            s,
+            nh,
+            hd,
             stream,
         )?;
 
@@ -2701,12 +2844,18 @@ impl GpuLoraOptimizerState {
             Ok(GpuBuffer::from_host(ctx, &vec![0.0f32; n])?)
         };
         Ok(Self {
-            m_lora_a_q: z(h * r)?,  v_lora_a_q: z(h * r)?,
-            m_lora_b_q: z(r * q_dim)?,  v_lora_b_q: z(r * q_dim)?,
-            m_lora_a_v: z(h * r)?,  v_lora_a_v: z(h * r)?,
-            m_lora_b_v: z(r * kv)?,  v_lora_b_v: z(r * kv)?,
-            m_input_norm: z(h)?,  v_input_norm: z(h)?,
-            m_post_attn_norm: z(h)?,  v_post_attn_norm: z(h)?,
+            m_lora_a_q: z(h * r)?,
+            v_lora_a_q: z(h * r)?,
+            m_lora_b_q: z(r * q_dim)?,
+            v_lora_b_q: z(r * q_dim)?,
+            m_lora_a_v: z(h * r)?,
+            v_lora_a_v: z(h * r)?,
+            m_lora_b_v: z(r * kv)?,
+            v_lora_b_v: z(r * kv)?,
+            m_input_norm: z(h)?,
+            v_input_norm: z(h)?,
+            m_post_attn_norm: z(h)?,
+            v_post_attn_norm: z(h)?,
         })
     }
 }
@@ -2764,7 +2913,12 @@ impl CudaNf4TransformerBlock {
 
         // === Step 1: FFN backward (NF4 transpose, no weight grads for frozen projections) ===
         self.backward_nf4_ffn(
-            grad_output, seq_len, hidden_size, intermediate_size, stream, scratch,
+            grad_output,
+            seq_len,
+            hidden_size,
+            intermediate_size,
+            stream,
+            scratch,
         )?;
 
         // === Step 2: Post-attn norm backward ===
@@ -2772,8 +2926,8 @@ impl CudaNf4TransformerBlock {
         rms_norm_backward(
             &scratch.residual1,
             &self.post_attn_norm_weight,
-            &scratch.grad_hidden,  // grad_from_ffn is accumulated in grad_hidden by backward_nf4_ffn
-            grad_input,            // temporarily store post-attn-norm grad here
+            &scratch.grad_hidden, // grad_from_ffn is accumulated in grad_hidden by backward_nf4_ffn
+            grad_input,           // temporarily store post-attn-norm grad here
             &mut grad_lora.grad_post_attn_norm,
             saturating_u32(seq_len),
             saturating_u32(hidden_size),
@@ -2787,7 +2941,7 @@ impl CudaNf4TransformerBlock {
 
         // === Step 3: Attention backward (NF4 + LoRA for Q/V) ===
         self.backward_nf4_attention(
-            grad_input,    // grad coming into attention (from residual1)
+            grad_input, // grad coming into attention (from residual1)
             seq_len, stream, scratch, grad_lora,
         )?;
 
@@ -2868,7 +3022,9 @@ impl CudaNf4TransformerBlock {
             &self.w_down_nf4,
             &self.w_down_scales,
             &mut scratch.grad_swiglu,
-            s, h, i_size,  // m=S, n=H (reduction), k=I (output cols)
+            s,
+            h,
+            i_size, // m=S, n=H (reduction), k=I (output cols)
             stream,
         )?;
 
@@ -2881,7 +3037,8 @@ impl CudaNf4TransformerBlock {
             &scratch.grad_swiglu,
             &scratch.up_out,
             &mut scratch.swiglu_out,
-            n_inter, stream,
+            n_inter,
+            stream,
         )?;
 
         // silu_backward: d_gate_raw = temp1 * silu'(gate_out)
@@ -2890,50 +3047,56 @@ impl CudaNf4TransformerBlock {
         silu_backward(
             &scratch.gate_out,
             &scratch.swiglu_out,
-            &mut scratch.up_out,   // d_gate stored here
+            &mut scratch.up_out, // d_gate stored here
             stream,
         )?;
 
         // d_up = d_swiglu * silu(gate) → store in gate_out (reuse)
         // First compute silu(gate) into ffn_out (temp)
-        silu_forward(
-            &scratch.gate_out,
-            &mut scratch.ffn_out,
-            n_inter, stream,
-        )?;
+        silu_forward(&scratch.gate_out, &mut scratch.ffn_out, n_inter, stream)?;
         // d_up = d_swiglu * silu(gate)
         elementwise_mul_forward(
             &scratch.grad_swiglu,
             &scratch.ffn_out,
-            &mut scratch.gate_out,  // d_up stored here
-            n_inter, stream,
+            &mut scratch.gate_out, // d_up stored here
+            n_inter,
+            stream,
         )?;
 
         // Step 3: Propagate through gate/up projections (NF4 transpose)
         // grad_norm2_gate = d_gate @ w_gate^T  [S,H]
         // W_gate is [I, H] in NF4
         gemm_nf4_backward_a(
-            &scratch.up_out,       // d_gate
+            &scratch.up_out, // d_gate
             &self.w_gate_nf4,
             &self.w_gate_scales,
-            &mut scratch.ffn_out,  // grad_norm2 part 1
-            s, i_size, h,          // m=S, n=I (reduction), k=H (output cols)
+            &mut scratch.ffn_out, // grad_norm2 part 1
+            s,
+            i_size,
+            h, // m=S, n=I (reduction), k=H (output cols)
             stream,
         )?;
 
         // grad_norm2_up = d_up @ w_up^T  [S,H]
         // W_up is [I, H] in NF4
         gemm_nf4_backward_a(
-            &scratch.gate_out,     // d_up
+            &scratch.gate_out, // d_up
             &self.w_up_nf4,
             &self.w_up_scales,
             &mut scratch.grad_hidden, // grad_norm2 part 2
-            s, i_size, h,
+            s,
+            i_size,
+            h,
             stream,
         )?;
 
         // Accumulate: grad_hidden = grad_norm2_gate + grad_norm2_up
-        cuda_add_inplace(&mut scratch.grad_hidden, &scratch.ffn_out, seq_len * hidden_size, stream)?;
+        cuda_add_inplace(
+            &mut scratch.grad_hidden,
+            &scratch.ffn_out,
+            seq_len * hidden_size,
+            stream,
+        )?;
 
         Ok(())
     }
@@ -2970,17 +3133,17 @@ impl CudaNf4TransformerBlock {
             grad_residual1,
             &self.w_o_nf4,
             &self.w_o_scales,
-            &mut scratch.attn_out,  // reuse as grad_attn_out [S, q_dim]
-            s, h, qd,
+            &mut scratch.attn_out, // reuse as grad_attn_out [S, q_dim]
+            s,
+            h,
+            qd,
             stream,
         )?;
 
         // Step 2: Attention mechanism backward
         // This is complex (softmax backward, batched GEMMs) — reuse the fp32 attention backward
         // infrastructure since attention operates on fp32 activations.
-        self.backward_nf4_attention_mechanism(
-            seq_len, num_heads, head_dim, stream, scratch,
-        )?;
+        self.backward_nf4_attention_mechanism(seq_len, num_heads, head_dim, stream, scratch)?;
 
         // After attention backward: scratch.norm1_out-related grads are accumulated.
         // grad_q is in scratch.q, grad_k in scratch.k, grad_v in scratch.v
@@ -2989,11 +3152,13 @@ impl CudaNf4TransformerBlock {
         // Base: grad_norm1_q = grad_q @ w_q^T  [S, H]
         // W_q is [q_dim, H] in NF4
         gemm_nf4_backward_a(
-            &scratch.q,             // grad_q [S, q_dim]
+            &scratch.q, // grad_q [S, q_dim]
             &self.w_q_nf4,
             &self.w_q_scales,
             &mut scratch.o_proj_out, // grad_norm1 (partial) [S, H]
-            s, qd, h,
+            s,
+            qd,
+            h,
             stream,
         )?;
 
@@ -3010,7 +3175,9 @@ impl CudaNf4TransformerBlock {
                 &scratch.lora_inter,
                 &scratch.q,
                 &mut grad_lora.grad_lora_b_q,
-                s, r, qd,
+                s,
+                r,
+                qd,
                 stream,
             )?;
 
@@ -3019,7 +3186,9 @@ impl CudaNf4TransformerBlock {
                 &scratch.q,
                 b_q,
                 &mut scratch.lora_inter, // reuse for grad_lora_inter
-                s, qd, r,
+                s,
+                qd,
+                r,
                 stream,
             )?;
 
@@ -3028,7 +3197,9 @@ impl CudaNf4TransformerBlock {
                 &scratch.norm1_out,
                 &scratch.lora_inter,
                 &mut grad_lora.grad_lora_a_q,
-                s, h, r,
+                s,
+                h,
+                r,
                 stream,
             )?;
 
@@ -3036,22 +3207,31 @@ impl CudaNf4TransformerBlock {
             gemm_backward_a(
                 &scratch.lora_inter,
                 a_q,
-                &mut scratch.lora_temp,  // [S, H]
-                s, r, h,
+                &mut scratch.lora_temp, // [S, H]
+                s,
+                r,
+                h,
                 stream,
             )?;
-            cuda_add_inplace(&mut scratch.o_proj_out, &scratch.lora_temp, seq_len * hidden_size, stream)?;
+            cuda_add_inplace(
+                &mut scratch.o_proj_out,
+                &scratch.lora_temp,
+                seq_len * hidden_size,
+                stream,
+            )?;
         }
 
         // Step 4: K projection backward (no LoRA on K)
         // grad_norm1_k = grad_k @ w_k^T  [S, H]
         // W_k is [kv_hidden, H] in NF4
         gemm_nf4_backward_a(
-            &scratch.k,           // grad_k [S, kv_hidden]
+            &scratch.k, // grad_k [S, kv_hidden]
             &self.w_k_nf4,
             &self.w_k_scales,
             &mut scratch.ffn_out, // temp [S, H]
-            s, kvh, h,
+            s,
+            kvh,
+            h,
             stream,
         )?;
         // Accumulate: grad_norm1 += grad_norm1_k
@@ -3061,11 +3241,13 @@ impl CudaNf4TransformerBlock {
         // Base: grad_norm1_v = grad_v @ w_v^T  [S, H]
         // W_v is [kv_hidden, H] in NF4
         gemm_nf4_backward_a(
-            &scratch.v,           // grad_v [S, kv_hidden]
+            &scratch.v, // grad_v [S, kv_hidden]
             &self.w_v_nf4,
             &self.w_v_scales,
             &mut scratch.ffn_out, // temp [S, H]
-            s, kvh, h,
+            s,
+            kvh,
+            h,
             stream,
         )?;
         cuda_add_inplace(&mut scratch.o_proj_out, &scratch.ffn_out, seq_len * hidden_size, stream)?;
@@ -3082,48 +3264,47 @@ impl CudaNf4TransformerBlock {
                 &scratch.lora_inter,
                 &scratch.v,
                 &mut grad_lora.grad_lora_b_v,
-                s, r, kvh,
+                s,
+                r,
+                kvh,
                 stream,
             )?;
 
             // grad_lora_inter = grad_v @ B_v^T  [S, rank]
-            gemm_backward_a(
-                &scratch.v,
-                b_v,
-                &mut scratch.lora_inter,
-                s, kvh, r,
-                stream,
-            )?;
+            gemm_backward_a(&scratch.v, b_v, &mut scratch.lora_inter, s, kvh, r, stream)?;
 
             // grad_A_v = norm1_out^T @ grad_lora_inter  [H, rank]
             gemm_backward_b(
                 &scratch.norm1_out,
                 &scratch.lora_inter,
                 &mut grad_lora.grad_lora_a_v,
-                s, h, r,
+                s,
+                h,
+                r,
                 stream,
             )?;
 
             // Add LoRA V's contribution to grad_norm1
-            gemm_backward_a(
-                &scratch.lora_inter,
-                a_v,
-                &mut scratch.lora_temp,
-                s, r, h,
+            gemm_backward_a(&scratch.lora_inter, a_v, &mut scratch.lora_temp, s, r, h, stream)?;
+            cuda_add_inplace(
+                &mut scratch.o_proj_out,
+                &scratch.lora_temp,
+                seq_len * hidden_size,
                 stream,
             )?;
-            cuda_add_inplace(&mut scratch.o_proj_out, &scratch.lora_temp, seq_len * hidden_size, stream)?;
         }
 
         // Step 6: Accumulated grad_norm1 is in scratch.o_proj_out → move to scratch.grad_hidden
         // for norm backward in the caller
         // SAFETY: D2D copy between same-sized GPU buffers
         unsafe {
-            scratch.grad_hidden.copy_from_buffer_async(&scratch.o_proj_out, stream).map_err(|e| {
-                crate::autograd::cuda_tensor::CudaTensorError::TransferFailed(format!(
-                    "grad_norm1 copy failed: {e}"
-                ))
-            })?;
+            scratch.grad_hidden.copy_from_buffer_async(&scratch.o_proj_out, stream).map_err(
+                |e| {
+                    crate::autograd::cuda_tensor::CudaTensorError::TransferFailed(format!(
+                        "grad_norm1 copy failed: {e}"
+                    ))
+                },
+            )?;
         }
 
         Ok(())
@@ -3152,8 +3333,11 @@ impl CudaNf4TransformerBlock {
         // Convert to batched layout [NH, S, HD]
         interleaved_to_batched_forward(
             &scratch.attn_out,
-            &mut scratch.attn_q_batched,  // grad_attn_batched [NH, S, HD]
-            s, nh, hd, stream,
+            &mut scratch.attn_q_batched, // grad_attn_batched [NH, S, HD]
+            s,
+            nh,
+            hd,
+            stream,
         )?;
 
         // Attention backward: attn_out = softmax(Q@K^T/√d) @ V
@@ -3248,48 +3432,96 @@ impl CudaNf4TransformerBlock {
         // AdamW step for each LoRA weight
         if let Some(ref mut a_q) = self.lora_a_q {
             adamw_step_cuda(
-                a_q, &grad_lora.grad_lora_a_q,
-                &mut state.m_lora_a_q, &mut state.v_lora_a_q,
-                lr, beta1, beta2, eps, weight_decay, step, saturating_u32(h * r),
+                a_q,
+                &grad_lora.grad_lora_a_q,
+                &mut state.m_lora_a_q,
+                &mut state.v_lora_a_q,
+                lr,
+                beta1,
+                beta2,
+                eps,
+                weight_decay,
+                step,
+                saturating_u32(h * r),
                 stream,
             )?;
         }
         if let Some(ref mut b_q) = self.lora_b_q {
             adamw_step_cuda(
-                b_q, &grad_lora.grad_lora_b_q,
-                &mut state.m_lora_b_q, &mut state.v_lora_b_q,
-                lr, beta1, beta2, eps, weight_decay, step, saturating_u32(r * q_dim),
+                b_q,
+                &grad_lora.grad_lora_b_q,
+                &mut state.m_lora_b_q,
+                &mut state.v_lora_b_q,
+                lr,
+                beta1,
+                beta2,
+                eps,
+                weight_decay,
+                step,
+                saturating_u32(r * q_dim),
                 stream,
             )?;
         }
         if let Some(ref mut a_v) = self.lora_a_v {
             adamw_step_cuda(
-                a_v, &grad_lora.grad_lora_a_v,
-                &mut state.m_lora_a_v, &mut state.v_lora_a_v,
-                lr, beta1, beta2, eps, weight_decay, step, saturating_u32(h * r),
+                a_v,
+                &grad_lora.grad_lora_a_v,
+                &mut state.m_lora_a_v,
+                &mut state.v_lora_a_v,
+                lr,
+                beta1,
+                beta2,
+                eps,
+                weight_decay,
+                step,
+                saturating_u32(h * r),
                 stream,
             )?;
         }
         if let Some(ref mut b_v) = self.lora_b_v {
             adamw_step_cuda(
-                b_v, &grad_lora.grad_lora_b_v,
-                &mut state.m_lora_b_v, &mut state.v_lora_b_v,
-                lr, beta1, beta2, eps, weight_decay, step, saturating_u32(r * kv),
+                b_v,
+                &grad_lora.grad_lora_b_v,
+                &mut state.m_lora_b_v,
+                &mut state.v_lora_b_v,
+                lr,
+                beta1,
+                beta2,
+                eps,
+                weight_decay,
+                step,
+                saturating_u32(r * kv),
                 stream,
             )?;
         }
 
         // AdamW step for norm weights
         adamw_step_cuda(
-            &mut self.input_norm_weight, &grad_lora.grad_input_norm,
-            &mut state.m_input_norm, &mut state.v_input_norm,
-            lr, beta1, beta2, eps, weight_decay, step, saturating_u32(h),
+            &mut self.input_norm_weight,
+            &grad_lora.grad_input_norm,
+            &mut state.m_input_norm,
+            &mut state.v_input_norm,
+            lr,
+            beta1,
+            beta2,
+            eps,
+            weight_decay,
+            step,
+            saturating_u32(h),
             stream,
         )?;
         adamw_step_cuda(
-            &mut self.post_attn_norm_weight, &grad_lora.grad_post_attn_norm,
-            &mut state.m_post_attn_norm, &mut state.v_post_attn_norm,
-            lr, beta1, beta2, eps, weight_decay, step, saturating_u32(h),
+            &mut self.post_attn_norm_weight,
+            &grad_lora.grad_post_attn_norm,
+            &mut state.m_post_attn_norm,
+            &mut state.v_post_attn_norm,
+            lr,
+            beta1,
+            beta2,
+            eps,
+            weight_decay,
+            step,
+            saturating_u32(h),
             stream,
         )?;
 
@@ -3305,28 +3537,16 @@ impl CudaNf4TransformerBlock {
         let download = |buf: &GpuBuffer<f32>| -> Result<Vec<f32>> {
             let mut host = vec![0.0f32; buf.len()];
             buf.copy_to_host(&mut host).map_err(|e| {
-                crate::autograd::cuda_tensor::CudaTensorError::TransferFailed(
-                    format!("LoRA weight download failed: {e}")
-                )
+                crate::autograd::cuda_tensor::CudaTensorError::TransferFailed(format!(
+                    "LoRA weight download failed: {e}"
+                ))
             })?;
             Ok(host)
         };
-        let a_q = self.lora_a_q.as_ref()
-            .map(&download)
-            .transpose()?
-            .unwrap_or_default();
-        let b_q = self.lora_b_q.as_ref()
-            .map(&download)
-            .transpose()?
-            .unwrap_or_default();
-        let a_v = self.lora_a_v.as_ref()
-            .map(&download)
-            .transpose()?
-            .unwrap_or_default();
-        let b_v = self.lora_b_v.as_ref()
-            .map(&download)
-            .transpose()?
-            .unwrap_or_default();
+        let a_q = self.lora_a_q.as_ref().map(&download).transpose()?.unwrap_or_default();
+        let b_q = self.lora_b_q.as_ref().map(&download).transpose()?.unwrap_or_default();
+        let a_v = self.lora_a_v.as_ref().map(&download).transpose()?.unwrap_or_default();
+        let b_v = self.lora_b_v.as_ref().map(&download).transpose()?.unwrap_or_default();
         Ok((a_q, b_q, a_v, b_v))
     }
 }

--- a/src/transformer/mod.rs
+++ b/src/transformer/mod.rs
@@ -23,11 +23,14 @@ pub mod wgpu_block;
 pub use attention::{LoRAProjection, MultiHeadAttention, MultiHeadAttentionWithLoRA};
 pub use config::TransformerConfig;
 #[cfg(feature = "cuda")]
-pub use cuda_block::{BlockWeights, CudaBlock, CudaGradWorkspace, CudaNf4TransformerBlock, CudaTransformerBlock, GpuBlockOptimizerState};
-#[cfg(feature = "cuda")]
-pub(crate) use cuda_block::{CudaBlockScratch, CudaLoraGradWorkspace, GpuLoraOptimizerState};
+pub use cuda_block::{
+    BlockWeights, CudaBlock, CudaGradWorkspace, CudaNf4TransformerBlock, CudaTransformerBlock,
+    GpuBlockOptimizerState,
+};
 #[cfg(not(feature = "cuda"))]
 pub use cuda_block::{CudaBlock, CudaTransformerBlock};
+#[cfg(feature = "cuda")]
+pub(crate) use cuda_block::{CudaBlockScratch, CudaLoraGradWorkspace, GpuLoraOptimizerState};
 pub use model::Transformer;
 pub use weights::{load_safetensors_weights, validate_weights, Architecture};
 #[cfg(feature = "gpu")]

--- a/src/transformer/norm.rs
+++ b/src/transformer/norm.rs
@@ -322,7 +322,8 @@ mod tests {
             assert!(
                 (wgrad1[i] - wgrad2[i]).abs() < 1e-5,
                 "Weight grad mismatch at [{i}]: unbatched={}, batched={}",
-                wgrad1[i], wgrad2[i]
+                wgrad1[i],
+                wgrad2[i]
             );
         }
     }

--- a/src/transformer/wgpu_block.rs
+++ b/src/transformer/wgpu_block.rs
@@ -131,13 +131,15 @@ impl WgpuForwardPass {
 
         for (i, layer) in model.layers.iter().enumerate() {
             let gate_data = layer.ffn.w_gate.data();
-            let gate_slice = gate_data.as_slice()
+            let gate_slice = gate_data
+                .as_slice()
                 .ok_or_else(|| format!("Layer {i}: gate weight not contiguous"))?;
             let up_data = layer.ffn.w_up.data();
-            let up_slice = up_data.as_slice()
-                .ok_or_else(|| format!("Layer {i}: up weight not contiguous"))?;
+            let up_slice =
+                up_data.as_slice().ok_or_else(|| format!("Layer {i}: up weight not contiguous"))?;
             let down_data = layer.ffn.w_down.data();
-            let down_slice = down_data.as_slice()
+            let down_slice = down_data
+                .as_slice()
                 .ok_or_else(|| format!("Layer {i}: down weight not contiguous"))?;
 
             let w_gate = Arc::new(device.device.create_buffer(&wgpu::BufferDescriptor {
@@ -185,7 +187,13 @@ impl WgpuForwardPass {
         let total_mb = total_bytes as f64 / (1024.0 * 1024.0);
         eprintln!("[wgpu] GPU-resident FFN weights: {num_layers} layers, {total_mb:.1} MB");
 
-        Ok(Self { device, config, num_layers, ffn_weights, pipeline_cache: RefCell::new(PipelineCache::new()) })
+        Ok(Self {
+            device,
+            config,
+            num_layers,
+            ffn_weights,
+            pipeline_cache: RefCell::new(PipelineCache::new()),
+        })
     }
 
     /// Execute forward pass through all transformer layers on GPU
@@ -279,8 +287,7 @@ impl WgpuForwardPass {
 
             // Upload input (always from CPU — small: seq_len * hidden_size)
             let input_data = input.data();
-            let input_slice = input_data.as_slice()
-                .ok_or("Input tensor not contiguous")?;
+            let input_slice = input_data.as_slice().ok_or("Input tensor not contiguous")?;
             let buf_input = batch.upload(input_slice);
 
             // KAIZEN-015: Import GPU-resident weights or fall back to CPU upload
@@ -293,14 +300,11 @@ impl WgpuForwardPass {
             } else {
                 // Fallback: upload weights from CPU tensors (original path)
                 let gate_data = w_gate.data();
-                let gate_slice = gate_data.as_slice()
-                    .ok_or("Gate weight not contiguous")?;
+                let gate_slice = gate_data.as_slice().ok_or("Gate weight not contiguous")?;
                 let up_data = w_up.data();
-                let up_slice = up_data.as_slice()
-                    .ok_or("Up weight not contiguous")?;
+                let up_slice = up_data.as_slice().ok_or("Up weight not contiguous")?;
                 let down_data = w_down.data();
-                let down_slice = down_data.as_slice()
-                    .ok_or("Down weight not contiguous")?;
+                let down_slice = down_data.as_slice().ok_or("Down weight not contiguous")?;
                 let g = batch.upload(gate_slice);
                 let u = batch.upload(up_slice);
                 let d = batch.upload(down_slice);
@@ -374,10 +378,8 @@ impl WgpuForwardPass {
         let n = batch_token_ids.len();
 
         // Step 1: Embed all samples on CPU
-        let mut hiddens: Vec<Tensor> = batch_token_ids
-            .iter()
-            .map(|ids| model.embed_tokens.forward(ids))
-            .collect();
+        let mut hiddens: Vec<Tensor> =
+            batch_token_ids.iter().map(|ids| model.embed_tokens.forward(ids)).collect();
 
         // Step 2: Layer-at-a-time processing
         // Attention on CPU SIMD (per-sample), FFN on GPU (all samples concatenated)
@@ -481,10 +483,10 @@ impl WgpuForwardPass {
 
     /// Get the adapter info for display
     pub fn adapter_info(&self) -> String {
-        format!("wgpu device ({}x{} model, {} layers)",
-            self.config.hidden_size,
-            self.config.intermediate_size,
-            self.num_layers)
+        format!(
+            "wgpu device ({}x{} model, {} layers)",
+            self.config.hidden_size, self.config.intermediate_size, self.num_layers
+        )
     }
 }
 
@@ -538,8 +540,8 @@ mod tests {
             head_dim_override: None,
         };
 
-        let pass = WgpuForwardPass::new_default(&config)
-            .expect("GPU available but creation failed");
+        let pass =
+            WgpuForwardPass::new_default(&config).expect("GPU available but creation failed");
 
         // Create small test tensors
         let input = Tensor::from_vec(vec![1.0; 8], false); // 1 token × 8 hidden
@@ -548,8 +550,7 @@ mod tests {
         let w_down = Tensor::from_vec(vec![0.1; 16 * 8], false);
 
         let gpu_result = pass.forward_ffn_gpu(
-            &input, &w_gate, &w_up, &w_down,
-            1, 8, 16,
+            &input, &w_gate, &w_up, &w_down, 1, 8, 16,
             None, // No GPU-resident weights for this test
         );
 

--- a/src/yaml_mode/bridge.rs
+++ b/src/yaml_mode/bridge.rs
@@ -94,8 +94,10 @@ fn convert_model(
     }
 
     // Convert architecture params to overrides
-    let architecture = model_cfg.architecture.as_ref().map(|arch| {
-        ArchitectureOverrides {
+    let architecture = model_cfg
+        .architecture
+        .as_ref()
+        .map(|arch| ArchitectureOverrides {
             hidden_size: arch.hidden_size,
             num_hidden_layers: arch.num_layers,
             num_attention_heads: arch.num_heads,
@@ -106,10 +108,16 @@ fn convert_model(
             rms_norm_eps: arch.rms_norm_eps,
             rope_theta: arch.rope_theta,
             use_bias: arch.use_bias,
-        }
-    }).filter(|o| !o.is_empty());
+        })
+        .filter(|o| !o.is_empty());
 
-    Ok(ModelRef { path: PathBuf::from(&model_cfg.source), layers, mode, config: None, architecture })
+    Ok(ModelRef {
+        path: PathBuf::from(&model_cfg.source),
+        layers,
+        mode,
+        config: None,
+        architecture,
+    })
 }
 
 /// Resolve the training data path from manifest data config.
@@ -323,9 +331,7 @@ fn convert_training(
 
     warn_unsupported_training_fields(training_cfg, warnings);
 
-    let deterministic = training_cfg
-        .and_then(|t| t.deterministic)
-        .unwrap_or(false);
+    let deterministic = training_cfg.and_then(|t| t.deterministic).unwrap_or(false);
 
     TrainingParams {
         epochs,
@@ -1319,8 +1325,7 @@ optimizer:
   name: adamw
   lr: 0.0003
 "#;
-        let manifest: TrainingManifest =
-            serde_yaml::from_str(yaml).expect("YAML should parse");
+        let manifest: TrainingManifest = serde_yaml::from_str(yaml).expect("YAML should parse");
         let result = manifest_to_spec(&manifest).expect("bridge should succeed");
         assert_eq!(result.spec.model.mode, ModelMode::Transformer);
         let arch = result.spec.model.architecture.expect("overrides should be set");

--- a/src/yaml_mode/manifest/shorthand.rs
+++ b/src/yaml_mode/manifest/shorthand.rs
@@ -48,14 +48,11 @@ pub fn parse_human_usize(s: &str) -> Result<usize, String> {
 
     // Parse the numeric part (allow float for "1.5K" etc.)
     if num_str.contains('.') {
-        let v: f64 =
-            num_str.parse().map_err(|e| format!("invalid number '{num_str}': {e}"))?;
+        let v: f64 = num_str.parse().map_err(|e| format!("invalid number '{num_str}': {e}"))?;
         Ok((v * multiplier as f64) as usize)
     } else {
-        let v: usize =
-            num_str.parse().map_err(|e| format!("invalid number '{num_str}': {e}"))?;
-        v.checked_mul(multiplier)
-            .ok_or_else(|| format!("overflow: {v} * {multiplier}"))
+        let v: usize = num_str.parse().map_err(|e| format!("invalid number '{num_str}': {e}"))?;
+        v.checked_mul(multiplier).ok_or_else(|| format!("overflow: {v} * {multiplier}"))
     }
 }
 

--- a/tests/distributed_integration.rs
+++ b/tests/distributed_integration.rs
@@ -13,8 +13,7 @@ use entrenar::finetune::RingAllReduceWorker;
 use entrenar::train::{
     checkpoint_path, hash_weights, should_save_checkpoint, verify_weight_consistency,
     BlockGradientSet, CheckpointPhase, DistributedBackend, DistributedCheckpointCoordinator,
-    DistributedRole, DistributedTrainConfig, PerBlockGradientAccumulator,
-    BLOCK_GRAD_COMPONENTS,
+    DistributedRole, DistributedTrainConfig, PerBlockGradientAccumulator, BLOCK_GRAD_COMPONENTS,
 };
 
 use std::net::{TcpListener, TcpStream};
@@ -27,13 +26,9 @@ use std::time::Instant;
 // =========================================================================
 
 fn setup_ring(n: usize) -> Vec<RingAllReduceWorker> {
-    let listeners: Vec<TcpListener> = (0..n)
-        .map(|_| TcpListener::bind("127.0.0.1:0").expect("bind"))
-        .collect();
-    let addrs: Vec<_> = listeners
-        .iter()
-        .map(|l| l.local_addr().expect("addr"))
-        .collect();
+    let listeners: Vec<TcpListener> =
+        (0..n).map(|_| TcpListener::bind("127.0.0.1:0").expect("bind")).collect();
+    let addrs: Vec<_> = listeners.iter().map(|l| l.local_addr().expect("addr")).collect();
 
     let accept_handles: Vec<_> = listeners
         .into_iter()
@@ -95,11 +90,8 @@ fn test_ddp_full_gradient_allreduce_4_workers() {
     let kv_hidden = 16;
     let intermediate = 128;
 
-    let block_sizes = PerBlockGradientAccumulator::compute_block_sizes(
-        hidden_size,
-        kv_hidden,
-        intermediate,
-    );
+    let block_sizes =
+        PerBlockGradientAccumulator::compute_block_sizes(hidden_size, kv_hidden, intermediate);
 
     let mut workers = setup_ring(world_size);
 
@@ -119,9 +111,7 @@ fn test_ddp_full_gradient_allreduce_4_workers() {
     // Compute expected mean manually
     let vec_len = worker_data[0].len();
     let expected: Vec<f32> = (0..vec_len)
-        .map(|i| {
-            worker_data.iter().map(|d| d[i]).sum::<f32>() / world_size as f32
-        })
+        .map(|i| worker_data.iter().map(|d| d[i]).sum::<f32>() / world_size as f32)
         .collect();
 
     // Run AllReduce in parallel threads
@@ -142,9 +132,7 @@ fn test_ddp_full_gradient_allreduce_4_workers() {
     // Last worker runs in main thread
     let mut main_data = last_data;
     let mut main_worker = last_worker;
-    main_worker
-        .allreduce(&mut main_data)
-        .expect("allreduce main");
+    main_worker.allreduce(&mut main_data).expect("allreduce main");
 
     let results: Vec<Vec<f32>> = handles
         .into_iter()
@@ -155,10 +143,7 @@ fn test_ddp_full_gradient_allreduce_4_workers() {
     // Verify: all workers have identical results
     for (rank, result) in results.iter().enumerate() {
         for (i, (&got, &exp)) in result.iter().zip(&expected).enumerate() {
-            assert!(
-                (got - exp).abs() < 1e-4,
-                "rank {rank} element {i}: got {got}, expected {exp}"
-            );
+            assert!((got - exp).abs() < 1e-4, "rank {rank} element {i}: got {got}, expected {exp}");
         }
     }
 
@@ -187,11 +172,7 @@ fn test_ddp_per_block_allreduce_reverse_order() {
         .map(|b| (0..total_per_block).map(|i| (b * 100 + i) as f32).collect())
         .collect();
     let grads_w1: Vec<Vec<f32>> = (0..num_blocks)
-        .map(|b| {
-            (0..total_per_block)
-                .map(|i| ((b * 100 + i) as f32) * 2.0)
-                .collect()
-        })
+        .map(|b| (0..total_per_block).map(|i| ((b * 100 + i) as f32) * 2.0).collect())
         .collect();
 
     // AllReduce each block in reverse order (mimics backward pass)
@@ -230,18 +211,12 @@ fn test_ddp_per_block_allreduce_reverse_order() {
     // Verify both workers got correct averaged gradients for each block
     for (b, data) in &results_w0 {
         for (i, (&got, &exp)) in data.iter().zip(&expected_blocks[*b]).enumerate() {
-            assert!(
-                (got - exp).abs() < 1e-3,
-                "w0 block {b} elem {i}: {got} != {exp}"
-            );
+            assert!((got - exp).abs() < 1e-3, "w0 block {b} elem {i}: {got} != {exp}");
         }
     }
     for (b, data) in &results_w1 {
         for (i, (&got, &exp)) in data.iter().zip(&expected_blocks[*b]).enumerate() {
-            assert!(
-                (got - exp).abs() < 1e-3,
-                "w1 block {b} elem {i}: {got} != {exp}"
-            );
+            assert!((got - exp).abs() < 1e-3, "w1 block {b} elem {i}: {got} != {exp}");
         }
     }
 }
@@ -305,9 +280,7 @@ fn test_communication_computation_overlap() {
             while compute_start.elapsed().as_millis() < 5 {}
         });
 
-        workers2[0]
-            .allreduce(&mut data)
-            .expect("allreduce overlap");
+        workers2[0].allreduce(&mut data).expect("allreduce overlap");
         compute_handle.join().expect("compute join");
         let _ = handle_comm.join().expect("comm join");
     }
@@ -359,10 +332,7 @@ fn test_multinode_checkpoint_coordination() {
     let hash0 = hash_weights(&weights_node0);
     let hash1 = hash_weights(&weights_node1);
     let hash2 = hash_weights(&weights_node2);
-    assert!(verify_weight_consistency(
-        &hash0,
-        &[hash0, hash1, hash2]
-    ));
+    assert!(verify_weight_consistency(&hash0, &[hash0, hash1, hash2]));
 
     // Phase 5: Complete and resume
     coord.complete();
@@ -372,10 +342,7 @@ fn test_multinode_checkpoint_coordination() {
 
     // Phase 6: Verify checkpoint path generation
     let path = checkpoint_path(std::path::Path::new("/shared/nfs/output"), 1000);
-    assert_eq!(
-        path.to_str().unwrap(),
-        "/shared/nfs/output/checkpoint-1000"
-    );
+    assert_eq!(path.to_str().unwrap(), "/shared/nfs/output/checkpoint-1000");
 }
 
 /// Multi-node wire protocol: simulate block gradient exchange between
@@ -408,9 +375,7 @@ fn test_multinode_block_gradient_exchange() {
             (0..total_per_block)
                 .map(|i| {
                     let sum: f32 = (0..world_size)
-                        .map(|r| {
-                            (r as f32 + 1.0) * (b as f32 + 1.0) * (i as f32 + 1.0)
-                        })
+                        .map(|r| (r as f32 + 1.0) * (b as f32 + 1.0) * (i as f32 + 1.0))
                         .sum();
                     sum / world_size as f32
                 })
@@ -455,13 +420,8 @@ fn test_multinode_block_gradient_exchange() {
     // Verify all nodes have identical averaged results for each block
     for b in 0..num_blocks {
         for rank in 0..world_size {
-            for (i, (&got, &exp)) in
-                all_results[rank][b].iter().zip(&expected[b]).enumerate()
-            {
-                assert!(
-                    (got - exp).abs() < 1e-2,
-                    "node {rank} block {b} elem {i}: {got} != {exp}"
-                );
+            for (i, (&got, &exp)) in all_results[rank][b].iter().zip(&expected[b]).enumerate() {
+                assert!((got - exp).abs() < 1e-2, "node {rank} block {b} elem {i}: {got} != {exp}");
             }
         }
         // All nodes must have identical results (C-DDP-001)
@@ -493,7 +453,8 @@ fn test_multinode_allreduce_with_checkpoint_barrier() {
     let handle = thread::spawn(move || {
         let mut results = Vec::new();
         for step in 1..=steps {
-            let mut data: Vec<f32> = (0..vec_size).map(|i| (step * 1000 + i) as f32 * 2.0).collect();
+            let mut data: Vec<f32> =
+                (0..vec_size).map(|i| (step * 1000 + i) as f32 * 2.0).collect();
             w1.allreduce(&mut data).expect("allreduce");
             results.push(data);
         }
@@ -533,11 +494,7 @@ fn test_multinode_allreduce_with_checkpoint_barrier() {
             step + 1
         );
         for (i, (&v0, &v1)) in results_0[step].iter().zip(&results_1[step]).enumerate() {
-            assert!(
-                (v0 - v1).abs() < 1e-3,
-                "step {} elem {i}: w0={v0} != w1={v1}",
-                step + 1
-            );
+            assert!((v0 - v1).abs() < 1e-3, "step {} elem {i}: w0={v0} != w1={v1}", step + 1);
         }
     }
 }
@@ -550,10 +507,7 @@ fn test_multinode_allreduce_with_checkpoint_barrier() {
 #[test]
 fn test_heterogeneous_device_detection() {
     let devices = entrenar::finetune::ComputeDevice::detect_all_devices();
-    assert!(
-        !devices.is_empty(),
-        "detect_all_devices() must return at least one device"
-    );
+    assert!(!devices.is_empty(), "detect_all_devices() must return at least one device");
 
     // At least CPU fallback
     let has_compute = devices.iter().any(|d| {
@@ -631,9 +585,7 @@ fn test_heterogeneous_gradient_allreduce() {
     // "CPU worker" gradients (scale 3.0)
     let cpu_grads: Vec<f32> = (0..total).map(|i| i as f32 * 3.0).collect();
 
-    let expected: Vec<f32> = (0..total)
-        .map(|i| i as f32 * (1.0 + 2.0 + 3.0) / 3.0)
-        .collect();
+    let expected: Vec<f32> = (0..total).map(|i| i as f32 * (1.0 + 2.0 + 3.0) / 3.0).collect();
 
     let mut w2 = workers.pop().unwrap();
     let mut w1 = workers.pop().unwrap();
@@ -656,21 +608,9 @@ fn test_heterogeneous_gradient_allreduce() {
 
     // All workers must have identical averaged gradients
     for (i, &exp) in expected.iter().enumerate() {
-        assert!(
-            (d0[i] - exp).abs() < 1e-3,
-            "cuda[{i}]: {} != {exp}",
-            d0[i]
-        );
-        assert!(
-            (r1[i] - exp).abs() < 1e-3,
-            "wgpu[{i}]: {} != {exp}",
-            r1[i]
-        );
-        assert!(
-            (r2[i] - exp).abs() < 1e-3,
-            "cpu[{i}]: {} != {exp}",
-            r2[i]
-        );
+        assert!((d0[i] - exp).abs() < 1e-3, "cuda[{i}]: {} != {exp}", d0[i]);
+        assert!((r1[i] - exp).abs() < 1e-3, "wgpu[{i}]: {} != {exp}", r1[i]);
+        assert!((r2[i] - exp).abs() < 1e-3, "cpu[{i}]: {} != {exp}", r2[i]);
     }
 
     // Weight consistency (C-DDP-001)
@@ -720,10 +660,7 @@ fn test_accumulator_micro_batch_cycle() {
         let flat = block.flatten();
         for (i, &val) in flat.iter().enumerate() {
             let expected = 2.5 * (i as f32 + 1.0);
-            assert!(
-                (val - expected).abs() < 1e-4,
-                "block elem {i}: {val} != {expected}"
-            );
+            assert!((val - expected).abs() < 1e-4, "block elem {i}: {val} != {expected}");
         }
     }
 
@@ -750,16 +687,8 @@ fn test_block_gradient_flatten_roundtrip() {
 
     // Verify roundtrip fidelity (C-WIRE-002)
     assert_eq!(grad.total_elements(), reconstructed.total_elements());
-    for (c, (orig, recon)) in grad
-        .components
-        .iter()
-        .zip(&reconstructed.components)
-        .enumerate()
-    {
-        assert_eq!(
-            orig, recon,
-            "component {c} roundtrip mismatch"
-        );
+    for (c, (orig, recon)) in grad.components.iter().zip(&reconstructed.components).enumerate() {
+        assert_eq!(orig, recon, "component {c} roundtrip mismatch");
     }
 }
 

--- a/tests/loss_function_accuracy.rs
+++ b/tests/loss_function_accuracy.rs
@@ -38,10 +38,7 @@ fn test_cross_entropy_matches_reference_3class() {
     let actual = loss.data()[0];
 
     let diff = (actual - reference).abs();
-    assert!(
-        diff < 1e-5,
-        "CE mismatch: actual={actual}, reference={reference}, diff={diff}"
-    );
+    assert!(diff < 1e-5, "CE mismatch: actual={actual}, reference={reference}, diff={diff}");
 }
 
 #[test]
@@ -112,12 +109,9 @@ fn test_mse_loss_matches_reference() {
     let target_vals = vec![1.5_f32, 2.5, 2.5, 4.5];
 
     // Reference: mean((pred - target)^2)
-    let reference: f32 = pred_vals
-        .iter()
-        .zip(&target_vals)
-        .map(|(p, t)| (p - t) * (p - t))
-        .sum::<f32>()
-        / pred_vals.len() as f32;
+    let reference: f32 =
+        pred_vals.iter().zip(&target_vals).map(|(p, t)| (p - t) * (p - t)).sum::<f32>()
+            / pred_vals.len() as f32;
 
     let mse = MSELoss;
     let pred = Tensor::from_vec(pred_vals, false);
@@ -126,10 +120,7 @@ fn test_mse_loss_matches_reference() {
     let actual = loss.data()[0];
 
     let diff = (actual - reference).abs();
-    assert!(
-        diff < 1e-6,
-        "MSE mismatch: actual={actual}, reference={reference}, diff={diff}"
-    );
+    assert!(diff < 1e-6, "MSE mismatch: actual={actual}, reference={reference}, diff={diff}");
 }
 
 #[test]
@@ -140,11 +131,7 @@ fn test_mse_loss_zero_for_identical() {
     let tgt = Tensor::from_vec(vals, false);
     let loss = mse.forward(&pred, &tgt);
 
-    assert!(
-        loss.data()[0].abs() < 1e-10,
-        "MSE of identical should be 0, got {}",
-        loss.data()[0]
-    );
+    assert!(loss.data()[0].abs() < 1e-10, "MSE of identical should be 0, got {}", loss.data()[0]);
 }
 
 #[test]
@@ -168,10 +155,7 @@ fn test_bce_with_logits_matches_reference() {
     let actual = loss.data()[0];
 
     let diff = (actual - reference).abs();
-    assert!(
-        diff < 1e-5,
-        "BCE mismatch: actual={actual}, reference={reference}, diff={diff}"
-    );
+    assert!(diff < 1e-5, "BCE mismatch: actual={actual}, reference={reference}, diff={diff}");
 }
 
 #[test]
@@ -180,9 +164,7 @@ fn test_causal_lm_loss_finite_for_valid_input() {
     let seq_len = 10;
 
     // Create logits: seq_len * vocab_size values
-    let logits: Vec<f32> = (0..seq_len * vocab_size)
-        .map(|i| ((i as f32) * 0.01).sin())
-        .collect();
+    let logits: Vec<f32> = (0..seq_len * vocab_size).map(|i| ((i as f32) * 0.01).sin()).collect();
 
     // Create targets: token IDs as floats (CausalLMLoss expects seq_len target values)
     let targets: Vec<f32> = (0..seq_len).map(|s| (s % vocab_size) as f32).collect();
@@ -192,14 +174,6 @@ fn test_causal_lm_loss_finite_for_valid_input() {
     let tgt = Tensor::from_vec(targets, false);
     let loss = lm_loss.forward(&pred, &tgt);
 
-    assert!(
-        loss.data()[0].is_finite(),
-        "CausalLM loss should be finite, got {}",
-        loss.data()[0]
-    );
-    assert!(
-        loss.data()[0] > 0.0,
-        "CausalLM loss should be positive, got {}",
-        loss.data()[0]
-    );
+    assert!(loss.data()[0].is_finite(), "CausalLM loss should be finite, got {}", loss.data()[0]);
+    assert!(loss.data()[0] > 0.0, "CausalLM loss should be positive, got {}", loss.data()[0]);
 }

--- a/tests/normalization_correctness.rs
+++ b/tests/normalization_correctness.rs
@@ -29,11 +29,7 @@ fn reference_rms_norm_f64(x: &[f32], gamma: &[f32], eps: f32) -> Vec<f32> {
 
     let rms: f64 = (x_f64.iter().map(|&v| v * v).sum::<f64>() / n + f64::from(eps)).sqrt();
 
-    x_f64
-        .iter()
-        .enumerate()
-        .map(|(i, &v)| (v / rms * f64::from(gamma[i])) as f32)
-        .collect()
+    x_f64.iter().enumerate().map(|(i, &v)| (v / rms * f64::from(gamma[i])) as f32).collect()
 }
 
 #[test]
@@ -75,10 +71,7 @@ fn test_layer_norm_zero_mean() {
 
     // With gamma=1 and beta=0, output mean should be ~0
     let mean: f32 = result.data().iter().sum::<f32>() / result.len() as f32;
-    assert!(
-        mean.abs() < 1e-5,
-        "LayerNorm output mean should be ~0, got {mean}"
-    );
+    assert!(mean.abs() < 1e-5, "LayerNorm output mean should be ~0, got {mean}");
 }
 
 #[test]
@@ -96,8 +89,8 @@ fn test_layer_norm_unit_variance() {
 
     // With gamma=1 and beta=0, output variance should be ~1
     let mean: f32 = result.data().iter().sum::<f32>() / result.len() as f32;
-    let variance: f32 = result.data().iter().map(|&v| (v - mean) * (v - mean)).sum::<f32>()
-        / result.len() as f32;
+    let variance: f32 =
+        result.data().iter().map(|&v| (v - mean) * (v - mean)).sum::<f32>() / result.len() as f32;
     assert!(
         (variance - 1.0).abs() < 1e-4,
         "LayerNorm output variance should be ~1, got {variance}"
@@ -121,10 +114,7 @@ fn test_layer_norm_gamma_scaling() {
 
     for (i, (&actual, &expected)) in result.data().iter().zip(reference.iter()).enumerate() {
         let diff = (actual - expected).abs();
-        assert!(
-            diff < 1e-5,
-            "LayerNorm gamma=2 mismatch at {i}: actual={actual}, ref={expected}"
-        );
+        assert!(diff < 1e-5, "LayerNorm gamma=2 mismatch at {i}: actual={actual}, ref={expected}");
     }
 }
 
@@ -145,17 +135,11 @@ fn test_layer_norm_beta_shift() {
 
     // Mean of output should be ~5 (beta shift)
     let mean: f32 = result.data().iter().sum::<f32>() / result.len() as f32;
-    assert!(
-        (mean - 5.0).abs() < 1e-4,
-        "LayerNorm with beta=5 should have mean ~5, got {mean}"
-    );
+    assert!((mean - 5.0).abs() < 1e-4, "LayerNorm with beta=5 should have mean ~5, got {mean}");
 
     for (i, (&actual, &expected)) in result.data().iter().zip(reference.iter()).enumerate() {
         let diff = (actual - expected).abs();
-        assert!(
-            diff < 1e-5,
-            "LayerNorm beta=5 mismatch at {i}: actual={actual}, ref={expected}"
-        );
+        assert!(diff < 1e-5, "LayerNorm beta=5 mismatch at {i}: actual={actual}, ref={expected}");
     }
 }
 
@@ -208,10 +192,7 @@ fn test_rms_norm_reference_correctness() {
     // Verify: rms = sqrt((1+4+9+16+25)/5 + eps) = sqrt(11 + eps) ≈ 3.3166
     let rms_sq: f32 = x.iter().map(|&v| v * v).sum::<f32>() / 5.0 + eps;
     let rms = rms_sq.sqrt();
-    assert!(
-        (rms - 3.3166).abs() < 0.01,
-        "RMS should be ~3.3166, got {rms}"
-    );
+    assert!((rms - 3.3166).abs() < 0.01, "RMS should be ~3.3166, got {rms}");
 
     // Check reference output
     for (i, (&xi, &ref_out)) in x.iter().zip(reference.iter()).enumerate() {
@@ -261,10 +242,7 @@ fn test_layer_norm_constant_input_produces_beta() {
 
     // When all inputs are equal, variance ≈ 0, normalized ≈ 0, output ≈ beta
     for (i, &v) in result.data().iter().enumerate() {
-        assert!(
-            (v - 3.0).abs() < 1e-2,
-            "Constant input: output[{i}] = {v}, expected ~3.0 (beta)"
-        );
+        assert!((v - 3.0).abs() < 1e-2, "Constant input: output[{i}] = {v}, expected ~3.0 (beta)");
     }
 }
 


### PR DESCRIPTION
## Summary
- Auto-formatted with `cargo fmt` (Rust 1.93.0)
- Prerequisite for unified CI lint gate deployment
- No functional changes — formatting only

## Context
Part of unified CI pipeline rollout ([spec](https://github.com/paiml/infra/blob/main/docs/specifications/unified-ci-pipeline.md)).
The lint gate requires `cargo fmt --check` to pass.

Generated with [Claude Code](https://claude.com/claude-code)