### PR TITLE
fix: clippy warnings (Rust 1.93)

### DIFF
--- a/crates/entrenar-common/src/error.rs
+++ b/crates/entrenar-common/src/error.rs
@@ -116,23 +116,23 @@ mod tests {
     fn test_error_codes_are_unique() {
         let errors = vec![
             EntrenarError::ConfigNotFound { path: "".into() },
-            EntrenarError::ConfigParsing { path: "".into(), message: "".into() },
+            EntrenarError::ConfigParsing { path: "".into(), message: String::new() },
             EntrenarError::ConfigValue {
-                field: "".into(),
-                message: "".into(),
-                suggestion: "".into(),
+                field: String::new(),
+                message: String::new(),
+                suggestion: String::new(),
             },
             EntrenarError::ModelNotFound { path: "".into() },
-            EntrenarError::UnsupportedFormat { format: "".into() },
-            EntrenarError::HuggingFace { message: "".into() },
+            EntrenarError::UnsupportedFormat { format: String::new() },
+            EntrenarError::HuggingFace { message: String::new() },
             EntrenarError::InsufficientMemory { required: 0.0, available: 0.0 },
             EntrenarError::ShapeMismatch { expected: vec![], actual: vec![] },
-            EntrenarError::Serialization { message: "".into() },
+            EntrenarError::Serialization { message: String::new() },
             EntrenarError::Cancelled,
-            EntrenarError::Internal { message: "".into() },
+            EntrenarError::Internal { message: String::new() },
         ];
 
-        let codes: Vec<_> = errors.iter().map(|e| e.code()).collect();
+        let codes: Vec<_> = errors.iter().map(super::EntrenarError::code).collect();
         let unique: std::collections::HashSet<_> = codes.iter().collect();
 
         // All codes except E050 and E051 should be unique
@@ -144,7 +144,7 @@ mod tests {
     fn test_user_errors_are_recoverable() {
         assert!(EntrenarError::ConfigNotFound { path: "".into() }.is_user_error());
         assert!(EntrenarError::Cancelled.is_user_error());
-        assert!(!EntrenarError::Internal { message: "".into() }.is_user_error());
+        assert!(!EntrenarError::Internal { message: String::new() }.is_user_error());
     }
 
     #[test]
@@ -224,7 +224,7 @@ mod tests {
         let errors: Vec<EntrenarError> = vec![
             EntrenarError::ConfigNotFound { path: "".into() },
             EntrenarError::Cancelled,
-            EntrenarError::Internal { message: "".into() },
+            EntrenarError::Internal { message: String::new() },
         ];
 
         for err in errors {

--- a/crates/entrenar-common/src/output.rs
+++ b/crates/entrenar-common/src/output.rs
@@ -244,8 +244,8 @@ mod tests {
         assert!(rendered.contains('┌'));
         assert!(rendered.contains('│'));
         assert!(rendered.contains('└'));
-        assert!(rendered.contains("A"));
-        assert!(rendered.contains("1"));
+        assert!(rendered.contains('A'));
+        assert!(rendered.contains('1'));
     }
 
     #[test]
@@ -309,8 +309,8 @@ mod tests {
         let table = TableBuilder::new().headers(vec!["A", "B"]).build();
 
         let rendered = table.render();
-        assert!(rendered.contains("A"));
-        assert!(rendered.contains("B"));
+        assert!(rendered.contains('A'));
+        assert!(rendered.contains('B'));
         // Should still have borders
         assert!(rendered.contains('┌'));
         assert!(rendered.contains('└'));

--- a/crates/entrenar-distill/src/config.rs
+++ b/crates/entrenar-distill/src/config.rs
@@ -418,11 +418,11 @@ output:
 
     #[test]
     fn test_progressive_config() {
-        let yaml = r#"
+        let yaml = r"
 enabled: true
 layer_mapping: [[0, 3], [1, 7], [2, 11]]
 weight: 0.3
-"#;
+";
         let config: ProgressiveConfig = serde_yaml::from_str(yaml).expect("config should be valid");
         assert!(config.enabled);
         assert_eq!(config.layer_mapping.len(), 3);

--- a/src/finetune/distributed.rs
+++ b/src/finetune/distributed.rs
@@ -276,13 +276,13 @@ impl WireMessage {
                 component_sizes,
             ),
             Self::AveragedBlockGradient { step, block_idx, gradients, component_sizes } => {
-                serialize_averaged_block(&mut buf, *step, *block_idx, gradients, component_sizes)
+                serialize_averaged_block(&mut buf, *step, *block_idx, gradients, component_sizes);
             }
             Self::NonBlockGradientPayload { step, worker_id, component, gradients } => {
-                serialize_non_block_grad(&mut buf, *step, *worker_id, *component, gradients)
+                serialize_non_block_grad(&mut buf, *step, *worker_id, *component, gradients);
             }
             Self::AveragedNonBlockGradient { step, component, gradients } => {
-                serialize_averaged_non_block(&mut buf, *step, *component, gradients)
+                serialize_averaged_non_block(&mut buf, *step, *component, gradients);
             }
         }
         buf

--- a/src/train/transformer_trainer/tests.rs
+++ b/src/train/transformer_trainer/tests.rs
@@ -461,7 +461,7 @@ fn test_deterministic_disabled_no_env_change() {
     // SAFETY: test runs single-threaded; remove_var needed to verify no-op behavior
     #[allow(clippy::disallowed_methods, unsafe_code)]
     unsafe {
-        std::env::remove_var("PYTHONHASHSEED")
+        std::env::remove_var("PYTHONHASHSEED");
     };
     config.apply_deterministic_settings();
     // PYTHONHASHSEED should NOT have been set


### PR DESCRIPTION
Auto-fixed clippy warnings for unified CI lint gate compliance.