### PR TITLE
feat: cuBLAS strided batched GEMM for attention (Phase 4)

### DIFF
--- a/.pmat/baseline.json
+++ b/.pmat/baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "3.6.1",
-  "created_at": "2026-03-05T16:56:53.882907213Z",
+  "created_at": "2026-03-05T17:19:19.413940917Z",
   "git_context": null,
   "files": {},
   "summary": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6068,9 +6068,9 @@ dependencies = [
 
 [[package]]
 name = "trueno-gpu"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "920ca97ec27a48babe0e9729565ea5e41a17f4ea5e2b77460080403849a2c113"
+checksum = "dd5e0ef5c33fa1806107a67d27b30316f1b57a27c6477f1cb97530ef7930c790"
 dependencies = [
  "batuta-common",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ hub-publish = ["hub", "dep:reqwest"]  # HuggingFace Hub publishing + leaderboard
 # Core PAIML stack
 ndarray = "0.16"
 trueno = { version = "0.16", features = ["parallel"] }  # SIMD-accelerated compute
-trueno-gpu = { version = "0.4.24", optional = true }  # CUDA compute for GPU training (0.4.24: cuBLAS tensor core GEMM)
+trueno-gpu = { version = "0.4.25", optional = true }  # CUDA compute for GPU training (0.4.25: cuBLAS strided batched GEMM)
 realizar = { version = "0.8", optional = true }  # CUDA inference engine with working GEMM
 aprender = "0.27"  # ML interpret module for explainability + .apr model format + pruning + tokenizers
 trueno-viz = { version = "0.2", features = ["terminal"] }  # Terminal visualization

--- a/src/autograd/cuda_forward/matmul.rs
+++ b/src/autograd/cuda_forward/matmul.rs
@@ -260,6 +260,34 @@ pub fn batched_4d_gemm_forward(
         CudaTensorError::KernelError("Failed to acquire kernel cache lock".to_string())
     })?;
 
+    // ALB-075 Phase 4: cuBLAS strided batched GEMM for attention (16x faster than PTX)
+    if let Some(cublas) = cache.cublas() {
+        let batch_count = (batch * heads) as i32;
+        let stride_a = i64::from(m) * i64::from(k);
+        let stride_b = i64::from(k) * i64::from(n);
+        let stride_c = i64::from(m) * i64::from(n);
+        return cublas
+            .gemm_f32_strided_batched_row_major(
+                m as i32,
+                n as i32,
+                k as i32,
+                1.0,
+                a.as_ptr(),
+                stride_a,
+                b.as_ptr(),
+                stride_b,
+                0.0,
+                c.as_ptr(),
+                stride_c,
+                batch_count,
+            )
+            .map_err(|e| {
+                CudaTensorError::KernelError(format!(
+                    "cuBLAS batched 4D GEMM failed: {e:?}"
+                ))
+            });
+    }
+
     let kernel = Batched4DGemmKernel::new(batch, heads, m, n, k);
     let tile_size = kernel.config.tile_size;
 


### PR DESCRIPTION
## Summary

- Adds cuBLAS tensor core fast path to `batched_4d_gemm_forward` for multi-head attention
- Uses `cublasSgemmStridedBatched` (trueno-gpu 0.4.25) instead of hand-written PTX
- Falls back to PTX when cuBLAS handle unavailable
- `batch_count = batch_size * num_heads` (64 for 350M config)

## Motivation

After Phase 1-3 cuBLAS linear GEMMs (PR #233, 3.19x speedup), attention GEMMs
became the next bottleneck at ~200ms/step. This Phase 4 change enables tensor
cores for attention score computation (QK^T and attn·V).

## Expected Impact

- Attention GEMM compute: ~200ms → ~12ms (16x speedup)
- Overall step time: ~1,379ms → ~1,180ms (15% further reduction)

## Test plan

- [x] `cargo build --features cuda,parquet` compiles cleanly
- [ ] 50M quick regression test (5 steps)
- [ ] 350M CUDA test (50 steps, verify loss trajectory)
- [ ] Measure actual step time improvement

Refs #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)