### PR TITLE
feat: TF32 tensor cores — trueno-gpu 0.4.26 (2x GEMM throughput)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6068,9 +6068,9 @@ dependencies = [
 
 [[package]]
 name = "trueno-gpu"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5e0ef5c33fa1806107a67d27b30316f1b57a27c6477f1cb97530ef7930c790"
+checksum = "ba4ac395c71d97f519c4902cfd613f9d59bbc617b08b8d577e71f99ee2f313f3"
 dependencies = [
  "batuta-common",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ hub-publish = ["hub", "dep:reqwest"]  # HuggingFace Hub publishing + leaderboard
 # Core PAIML stack
 ndarray = "0.16"
 trueno = { version = "0.16", features = ["parallel"] }  # SIMD-accelerated compute
-trueno-gpu = { version = "0.4.25", optional = true }  # CUDA compute for GPU training (0.4.25: cuBLAS strided batched GEMM)
+trueno-gpu = { version = "0.4.26", optional = true }  # CUDA compute for GPU training (0.4.26: TF32 tensor cores for FP32 GEMMs)
 realizar = { version = "0.8", optional = true }  # CUDA inference engine with working GEMM
 aprender = "0.27"  # ML interpret module for explainability + .apr model format + pruning + tokenizers
 trueno-viz = { version = "0.2", features = ["terminal"] }  # Terminal visualization


### PR DESCRIPTION
## Summary

- Upgrades trueno-gpu to 0.4.26 which enables `CUBLAS_COMPUTE_32F_FAST_TF32` for all FP32 GEMMs
- Expected ~2x throughput improvement for forward+backward pass GEMMs
- TF32: 10-bit mantissa tensor cores — standard for NN training (PyTorch default)

## Test plan

- [x] `cargo check --features cuda` passes
- [ ] Dogfood on albor 350M training — measure tok/s improvement

Refs #235